### PR TITLE
Acd 4136 pytest-xdist incompatibility issue fix

### DIFF
--- a/pytest_splunk_addon/standard_lib/app_test_generator.py
+++ b/pytest_splunk_addon/standard_lib/app_test_generator.py
@@ -79,5 +79,5 @@ class AppTestGenerator(object):
                 self.seen_tests.add(each_param.id)
 
         # Sort the test generated.
-        # As pytest-xdist expects the tests to be ordered
+        # ACD-4138: As pytest-xdist expects the tests to be ordered
         return sorted(param_list, key=lambda param:param.id)

--- a/pytest_splunk_addon/standard_lib/app_test_generator.py
+++ b/pytest_splunk_addon/standard_lib/app_test_generator.py
@@ -72,7 +72,10 @@ class AppTestGenerator(object):
         Yields:
             Generator: De-duplicated pytest.param
         """
+        param_list = []
         for each_param in test_list:
             if each_param.id not in self.seen_tests:
-                yield each_param
+                param_list.append(each_param)
                 self.seen_tests.add(each_param.id)
+
+        return sorted(param_list, key=lambda param:param.id)

--- a/pytest_splunk_addon/standard_lib/app_test_generator.py
+++ b/pytest_splunk_addon/standard_lib/app_test_generator.py
@@ -78,4 +78,6 @@ class AppTestGenerator(object):
                 param_list.append(each_param)
                 self.seen_tests.add(each_param.id)
 
+        # Sort the test generated.
+        # As pytest-xdist expects the tests to be ordered
         return sorted(param_list, key=lambda param:param.id)

--- a/pytest_splunk_addon/standard_lib/fields_tests/test_generator.py
+++ b/pytest_splunk_addon/standard_lib/fields_tests/test_generator.py
@@ -58,9 +58,11 @@ class FieldTestGenerator(object):
 
             # Generate a test case for all the fields in the classname 
             if self._contains_classname(fields_group, ["EXTRACT", "REPORT"]):
+                test_group = fields_group.copy()
+                test_group["fields"] = [each.__dict__ for each in test_group["fields"]]
                 yield pytest.param( 
-                    fields_group,
-                    id="{stanza}::{classname}".format(**fields_group)
+                    test_group,
+                    id="{stanza}::{classname}".format(**test_group)
                 )
 
             # For each field mentioned in field_bank, a separate 
@@ -73,7 +75,7 @@ class FieldTestGenerator(object):
 
                 # Create a dictionary for a single field with classname and stanza
                 one_field_group = fields_group.copy()
-                one_field_group["fields"] = [each_field]
+                one_field_group["fields"] = [each_field.__dict__]
                 if fields_group["classname"] != "field_bank":
                     test_type = "field"
                 else:

--- a/pytest_splunk_addon/standard_lib/fields_tests/test_generator.py
+++ b/pytest_splunk_addon/standard_lib/fields_tests/test_generator.py
@@ -58,6 +58,8 @@ class FieldTestGenerator(object):
 
             # Generate a test case for all the fields in the classname 
             if self._contains_classname(fields_group, ["EXTRACT", "REPORT"]):
+                # Convert the Field objects to dictionary to resolve the shared
+                # memory issue with pytest-xdist parallel execution
                 test_group = fields_group.copy()
                 test_group["fields"] = [each.__dict__ for each in test_group["fields"]]
                 yield pytest.param( 
@@ -74,6 +76,8 @@ class FieldTestGenerator(object):
             for each_field in fields_group["fields"]:
 
                 # Create a dictionary for a single field with classname and stanza
+                # Convert the Field object to dictionary to resolve the shared
+                # memory issue with pytest-xdist parallel execution
                 one_field_group = fields_group.copy()
                 one_field_group["fields"] = [each_field.__dict__]
                 if fields_group["classname"] != "field_bank":

--- a/pytest_splunk_addon/standard_lib/fields_tests/test_generator.py
+++ b/pytest_splunk_addon/standard_lib/fields_tests/test_generator.py
@@ -58,7 +58,7 @@ class FieldTestGenerator(object):
 
             # Generate a test case for all the fields in the classname 
             if self._contains_classname(fields_group, ["EXTRACT", "REPORT"]):
-                # Convert the Field objects to dictionary to resolve the shared
+                # ACD-4136: Convert the Field objects to dictionary to resolve the shared
                 # memory issue with pytest-xdist parallel execution
                 test_group = fields_group.copy()
                 test_group["fields"] = [each.__dict__ for each in test_group["fields"]]
@@ -74,9 +74,8 @@ class FieldTestGenerator(object):
 
             # Generate test-cases for each field in classname one by one 
             for each_field in fields_group["fields"]:
-
                 # Create a dictionary for a single field with classname and stanza
-                # Convert the Field object to dictionary to resolve the shared
+                # ACD-4136: Convert the Field object to dictionary to resolve the shared
                 # memory issue with pytest-xdist parallel execution
                 one_field_group = fields_group.copy()
                 one_field_group["fields"] = [each_field.__dict__]

--- a/pytest_splunk_addon/standard_lib/fields_tests/test_templates.py
+++ b/pytest_splunk_addon/standard_lib/fields_tests/test_templates.py
@@ -5,6 +5,7 @@ Includes the test scenarios to check the field extractions of an Add-on.
 import pprint
 import logging
 import pytest
+from ..addon_parser import Field
 INTERVAL = 3
 RETRIES = 3
 
@@ -15,6 +16,7 @@ class FieldTestTemplates(object):
     logger = logging.getLogger("pytest-splunk-addon-tests")
 
     @pytest.mark.splunk_addon_internal_errors
+    @pytest.mark.skip
     def test_splunk_internal_errors(
         self, splunk_search_util, record_property, caplog
     ):
@@ -62,6 +64,7 @@ class FieldTestTemplates(object):
             f"{splunk_app_positive_fields['stanza']}\""
         )
         for field in splunk_app_positive_fields["fields"]:
+            field = Field(field)
             expected_values = ", ".join([f'"{each}"' for each in field.expected_values])
             negative_values = ", ".join([f'"{each}"' for each in field.negative_values])
 
@@ -110,6 +113,7 @@ class FieldTestTemplates(object):
         )
 
         for field in splunk_app_negative_fields["fields"]:
+            field = Field(field)
             negative_values = ", ".join([f'"{each}"' for each in field.negative_values])
 
             search = (search + f' AND ({field} IN ({negative_values}))')
@@ -130,6 +134,7 @@ class FieldTestTemplates(object):
 
 
     @pytest.mark.splunk_addon_searchtime
+    @pytest.mark.skip
     def test_tags(
         self, splunk_search_util, splunk_app_tags, record_property, caplog
     ):
@@ -174,6 +179,7 @@ class FieldTestTemplates(object):
 
 
     @pytest.mark.splunk_addon_searchtime
+    @pytest.mark.skip
     def test_eventtype(
         self,
         splunk_search_util,

--- a/pytest_splunk_addon/standard_lib/fields_tests/test_templates.py
+++ b/pytest_splunk_addon/standard_lib/fields_tests/test_templates.py
@@ -16,7 +16,6 @@ class FieldTestTemplates(object):
     logger = logging.getLogger("pytest-splunk-addon-tests")
 
     @pytest.mark.splunk_addon_internal_errors
-    @pytest.mark.skip
     def test_splunk_internal_errors(
         self, splunk_search_util, record_property, caplog
     ):
@@ -63,8 +62,8 @@ class FieldTestTemplates(object):
             f" {splunk_app_positive_fields['stanza_type']}=\""
             f"{splunk_app_positive_fields['stanza']}\""
         )
-        for field in splunk_app_positive_fields["fields"]:
-            field = Field(field)
+        for field_dict in splunk_app_positive_fields["fields"]:
+            field = Field(field_dict)
             expected_values = ", ".join([f'"{each}"' for each in field.expected_values])
             negative_values = ", ".join([f'"{each}"' for each in field.negative_values])
 
@@ -112,8 +111,8 @@ class FieldTestTemplates(object):
             f"{splunk_app_negative_fields['stanza']}\""
         )
 
-        for field in splunk_app_negative_fields["fields"]:
-            field = Field(field)
+        for field_dict in splunk_app_negative_fields["fields"]:
+            field = Field(field_dict)
             negative_values = ", ".join([f'"{each}"' for each in field.negative_values])
 
             search = (search + f' AND ({field} IN ({negative_values}))')
@@ -134,7 +133,6 @@ class FieldTestTemplates(object):
 
 
     @pytest.mark.splunk_addon_searchtime
-    @pytest.mark.skip
     def test_tags(
         self, splunk_search_util, splunk_app_tags, record_property, caplog
     ):
@@ -179,7 +177,6 @@ class FieldTestTemplates(object):
 
 
     @pytest.mark.splunk_addon_searchtime
-    @pytest.mark.skip
     def test_eventtype(
         self,
         splunk_search_util,


### PR DESCRIPTION
There were 2 issue 
1. ACD-4138: The test generated were not ordered.
2. ACD-4136: The Field class was causing the issue in test scenarios.

ACD-4138
* The issue was resolved by sorting the test parameters 

ACD-4136
* By troubleshooting the issue, I checked that the error only occurs if the objects of Field class are provided to the test scenarios
* If the same information was provided in JSON format, the tests started working properly. 
* I'll update the detailed analysis in the ticket comment. 

Test execution with pytest-xdist plugin
![image](https://user-images.githubusercontent.com/37693483/79864266-cf387a80-83f6-11ea-9fad-a3f6ab03f501.png)
