### PR TITLE
ACD-4178: Fixed mismatched paranthesis for not_allowed_in_search test…

### DIFF
--- a/pytest_splunk_addon/standard_lib/cim_tests/test_templates.py
+++ b/pytest_splunk_addon/standard_lib/cim_tests/test_templates.py
@@ -23,6 +23,35 @@ class CIMTestTemplates(object):
 
     logger = logging.getLogger("pytest-splunk-addon-cim-tests")
 
+    @pytest.mark.parametrize(
+        "app_name",
+        [pytest.param("Splunk_SA_CIM", marks=[pytest.mark.splunk_searchtime_cim])],
+    )
+    def test_app_installed(self, splunk_search_util, app_name, record_property):
+        """
+        This test case checks that addon is installed/enabled in the Splunk instance.
+        Args:
+            splunk_search_util (SearchUtil): Object that helps to search on Splunk.
+            app_name (string): Add-on name.
+            record_property (fixture): Document facts of test cases.
+        """
+
+        record_property("app_name", app_name)
+        # Search Query
+        search = "| rest /servicesNS/nobody/{}/configs/conf-app/ui".format(app_name)
+        self.logger.info(f"Executing the search query: {search}")
+        record_property("search", search)
+
+        result = splunk_search_util.checkQueryCountIsGreaterThanZero(
+            search, interval=INTERVAL, retries=RETRIES
+        )
+
+        assert result, (
+            f"App {app_name} is not installed/enabled in this Splunk instance."
+            f"\nThe plugin requires the {app_name} to be installed/enabled in the Splunk instance."
+            f"\nPlease install the app and execute the tests again."
+        )
+
     @pytest.mark.splunk_searchtime_cim
     @pytest.mark.splunk_searchtime_cim_fields
     def test_cim_required_fields(
@@ -45,14 +74,10 @@ class CIMTestTemplates(object):
         for each_set in cim_data_set:
             base_search += " | search {}".format(each_set.search_constraints)
 
-        base_search += " | search {}".format(
-            cim_tag_stanza
-        )
+        base_search += " | search {}".format(cim_tag_stanza)
 
         test_helper = FieldTestHelper(
-            splunk_search_util, 
-            cim_fields,
-            interval=INTERVAL, retries=RETRIES
+            splunk_search_util, cim_fields, interval=INTERVAL, retries=RETRIES
         )
         # Execute the query and get the results
         results = test_helper.test_field(base_search)
@@ -63,15 +88,15 @@ class CIMTestTemplates(object):
         # what went wrong very quickly.
 
         if len(cim_fields) == 0:
-            # If no fields are there, check that the events are mapped 
-            # with the data model 
+            # If no fields are there, check that the events are mapped
+            # with the data model
             assert results, (
                 "0 Events mapped with the dataset."
                 f"\n{test_helper.format_exc_message()}"
             )
         if len(cim_fields) == 1:
             test_field = cim_fields[0]
-            # If the field is required, 
+            # If the field is required,
             #   there should be events mapped with the data model
             # If the field is conditional,
             #   It's fine if no events matched the condition
@@ -80,18 +105,17 @@ class CIMTestTemplates(object):
                 f"\n{test_helper.format_exc_message()}"
             )
             # The field should be extracted if event count > 0
-            assert all([
-                    each_field["field_count"] > 0
-                    for each_field in results
-                ]), (
+            assert all([each_field["field_count"] > 0 for each_field in results]), (
                 f"Field {test_field} is not extracted in any events."
                 f"\n{test_helper.format_exc_message()}"
             )
-            # The field should be extracted in all events mapped 
-            assert all([
+            # The field should be extracted in all events mapped
+            assert all(
+                [
                     each_field["field_count"] == each_field["event_count"]
                     for each_field in results
-                ]), (
+                ]
+            ), (
                 f"Field {test_field} is not extracted in some events."
                 f"\n{test_helper.format_exc_message()}"
             )
@@ -112,17 +136,113 @@ class CIMTestTemplates(object):
             sourcetype_fields = dict()
             for each_result in results:
                 sourcetype_fields.setdefault(
-                        (each_result["source"], each_result["sourcetype"]),
-                        list()
-                    ).extend(
-                    [each_result["field_count"], each_result["valid_field_count"]]
-                )
+                    (each_result["source"], each_result["sourcetype"]), list()
+                ).extend([each_result["field_count"], each_result["valid_field_count"]])
             for sourcetype_fields in sourcetype_fields.values():
                 assert len(set(sourcetype_fields)) == 1, (
                     "All fields from the field-cluster should be extracted with valid values if any one field is extracted."
                     f"\n{test_helper.format_exc_message()}"
                 )
 
+    @pytest.mark.splunk_searchtime_cim
+    @pytest.mark.splunk_searchtime_cim_fields_not_allowed_in_search
+    def test_cim_fields_not_allowed_in_search(
+        self,
+        splunk_search_util,
+        splunk_searchtime_cim_fields_not_allowed_in_search,
+        record_property,
+    ):
+        cim_dataset = splunk_searchtime_cim_fields_not_allowed_in_search["data_set"]
+        cim_fields = splunk_searchtime_cim_fields_not_allowed_in_search["fields"]
+        cim_tag_stanza = splunk_searchtime_cim_fields_not_allowed_in_search[
+            "tag_stanza"
+        ]
+
+        # Search Query
+
+        base_search = "search"
+        for each_set in cim_dataset:
+            base_search += " | search {}".format(each_set.search_constraints)
+
+        base_search += " | search {}".format(cim_tag_stanza)
+
+        base_search += " AND ("
+        for each_field in cim_fields:
+            base_search += " ({}=*) OR".format(each_field.name)
+
+        # To remove the extra OR at the end of search
+        base_search = base_search[:-2]
+        base_search += ")"
+
+        if not cim_tag_stanza:
+            base_search = base_search.replace("search OR", "search")
+
+        base_search += " | stats "
+
+        for each_field in cim_fields:
+            base_search += " count({fname}) AS {fname}".format(fname=each_field.name)
+
+        base_search += " by source, sourcetype"
+        record_property("search", base_search)
+        self.logger.info("base_search: %s", base_search)
+        results = list(
+            splunk_search_util.getFieldValuesList(
+                base_search, interval=INTERVAL, retries=RETRIES
+            )
+        )
+
+        violations = []
+        if results:
+            violations = [
+                [
+                    each_elem["source"],
+                    each_elem["sourcetype"],
+                    field.name,
+                    each_elem.get(field.name),
+                ]
+                for each_elem in results
+                for field in cim_fields
+                if not each_elem.get(field.name) == "0"
+                and not each_elem.get(field.name) == each_elem["sourcetype"]
+            ]
+
+            violation_str = (
+                "The fields should not be extracted in the dataset"
+                "\nThese fields are automatically provided by asset and identity"
+                " correlation features of applications like Splunk Enterprise Security."
+                "\nDo not define extractions for these fields when writing add-ons."
+                "\nExpected eventcount: 0 \n\n"
+            )
+            violation_str += FieldTestHelper.get_table_output(
+                headers=["Source", "Sourcetype", "Fields", "Event Count"],
+                value_list=violations,
+            )
+
+        assert not violations, violation_str
+
+    @pytest.mark.splunk_searchtime_cim
+    @pytest.mark.splunk_searchtime_cim_fields_not_allowed_in_props
+    def test_cim_fields_not_allowed_in_props(
+        self, splunk_searchtime_cim_fields_not_allowed_in_props, record_property
+    ):
+        result_str = (
+            "The field extractions are not allowed in the configuration files"
+            "\nThese fields are automatically provided by asset and identity"
+            " correlation features of applications like Splunk Enterprise Security."
+            "\nDo not define extractions for these fields when writing add-ons.\n\n"
+        )
+
+        result_str += FieldTestHelper.get_table_output(
+            headers=["Stanza", "Classname", "Fieldname"],
+            value_list=[
+                [data["stanza"], data["classname"], data["name"]]
+                for data in splunk_searchtime_cim_fields_not_allowed_in_props["fields"]
+            ],
+        )
+
+        assert not splunk_searchtime_cim_fields_not_allowed_in_props[
+            "fields"
+        ], result_str
 
     @pytest.mark.splunk_searchtime_cim
     @pytest.mark.splunk_searchtime_cim_mapped_datamodel
@@ -199,126 +319,4 @@ class CIMTestTemplates(object):
             "Multiple data models are mapped with an eventtype"
             f"\nQuery result greater than 0.\nsearch=\n{search} \n \n"
             f"Event type which associated with multiple data model \n{result_str}"
-        )
-
-
-    @pytest.mark.splunk_searchtime_cim
-    @pytest.mark.splunk_searchtime_cim_fields_not_allowed_in_search
-    def test_cim_fields_not_allowed_in_search(
-        self,
-        splunk_search_util,
-        splunk_searchtime_cim_fields_not_allowed_in_search,
-        record_property,
-    ):
-        # Search Query
-
-        base_search = "search"
-        for each_set in splunk_searchtime_cim_fields_not_allowed_in_search["data_set"]:
-            base_search += " ({})".format(each_set.search_constraints)
-
-        base_search += " AND ({}) ".format(
-            splunk_searchtime_cim_fields_not_allowed_in_search["tag_stanza"]
-        )
-
-        base_search += " AND ("
-        for each_field in splunk_searchtime_cim_fields_not_allowed_in_search["fields"]:
-            base_search += " ({}=*) OR".format(each_field.name)
-
-        # To remove the extra OR at the end of search
-        base_search = base_search[:-2]
-        base_search += ")"
-
-        if not splunk_searchtime_cim_fields_not_allowed_in_search["tag_stanza"]:
-            base_search = base_search.replace("search OR", "search")
-
-        base_search += " | stats "
-
-        for each_field in splunk_searchtime_cim_fields_not_allowed_in_search["fields"]:
-            base_search += " count({fname}) AS {fname}".format(fname=each_field.name)
-
-        base_search += " by sourcetype"
-        record_property("search", base_search)
-        self.logger.info("base_search: %s", base_search)
-        results = list(
-            splunk_search_util.getFieldValuesList(
-                base_search, interval=INTERVAL, retries=RETRIES
-            )
-        )
-
-        violations = []
-        if results:
-            violations = [
-                [each_elem["sourcetype"], field.name, each_elem.get(field.name)]
-                for each_elem in results
-                for field in splunk_searchtime_cim_fields_not_allowed_in_search[
-                    "fields"
-                ]
-                if not each_elem.get(field.name) == "0"
-                and not each_elem.get(field.name) == each_elem["sourcetype"]
-            ]
-
-            violation_str = (
-                "The fields should not be extracted in the dataset"
-                "\nThese fields are automatically provided by asset and identity"
-                " correlation features of applications like Splunk Enterprise Security."
-                "\nDo not define extractions for these fields when writing add-ons."
-                "\nExpected eventcount: 0 \n\n"
-            )
-            violation_str += FieldTestHelper.get_table_output(
-                headers=["Sourcetype", "Fields", "Event Count"], value_list=violations
-            )
-
-        assert not violations, violation_str
-
-    @pytest.mark.splunk_searchtime_cim
-    @pytest.mark.splunk_searchtime_cim_fields_not_allowed_in_props
-    def test_cim_fields_not_allowed_in_props(
-        self, splunk_searchtime_cim_fields_not_allowed_in_props, record_property
-    ):
-        result_str = (
-            "The field extractions are not allowed in the configuration files"
-            "\nThese fields are automatically provided by asset and identity"
-            " correlation features of applications like Splunk Enterprise Security."
-            "\nDo not define extractions for these fields when writing add-ons.\n\n"
-        )
-
-        result_str += FieldTestHelper.get_table_output(
-            headers=["Stanza", "Classname", "Fieldname"],
-            value_list=[
-                [data["stanza"], data["classname"], data["name"]]
-                for data in splunk_searchtime_cim_fields_not_allowed_in_props["fields"]
-            ],
-        )
-
-        assert not splunk_searchtime_cim_fields_not_allowed_in_props[
-            "fields"
-        ], result_str
-
-    @pytest.mark.parametrize(
-        "app_name",
-        [pytest.param("Splunk_SA_CIM", marks=[pytest.mark.splunk_searchtime_cim])],
-    )
-    def test_app_installed(self, splunk_search_util, app_name, record_property):
-        """
-        This test case checks that addon is installed/enabled in the Splunk instance.
-        Args:
-            splunk_search_util (SearchUtil): Object that helps to search on Splunk.
-            app_name (string): Add-on name.
-            record_property (fixture): Document facts of test cases.
-        """
-
-        record_property("app_name", app_name)
-        # Search Query
-        search = "| rest /servicesNS/nobody/{}/configs/conf-app/ui".format(app_name)
-        self.logger.info(f"Executing the search query: {search}")
-        record_property("search", search)
-
-        result = splunk_search_util.checkQueryCountIsGreaterThanZero(
-            search, interval=INTERVAL, retries=RETRIES
-        )
-
-        assert result, (
-            f"App {app_name} is not installed/enabled in this Splunk instance."
-            f"\nThe plugin requires the {app_name} to be installed/enabled in the Splunk instance."
-            f"\nPlease install the app and execute the tests again."
         )


### PR DESCRIPTION
The test test_cim_fields_not_allowed_in_search generated for some datasets makes an invalid Splunk query with error  `Unable to parse the search: unbalanced parentheses`  which is fixed in this branch.