### PR TITLE
ACD-4186: Updated action and date field in Network_Traffic and Malwar…

### DIFF
--- a/pytest_splunk_addon/standard_lib/data_models/Malware.json
+++ b/pytest_splunk_addon/standard_lib/data_models/Malware.json
@@ -21,7 +21,7 @@
         },
         {
           "name": "date",
-          "type": "required",
+          "type": "not_allowed_in_search",
           "comment": "The date of the malware event."
         },
         {

--- a/pytest_splunk_addon/standard_lib/data_models/Network_Traffic.json
+++ b/pytest_splunk_addon/standard_lib/data_models/Network_Traffic.json
@@ -15,7 +15,7 @@
       "fields": [
         {
           "name": "action",
-          "type": "not_allowed_in_search",
+          "type": "required",
           "expected_values": ["allowed", "blocked", "teardown", "flow"],
           "comment": "The action taken by the network device."
         },


### PR DESCRIPTION
Changes:
1. In Network Traffic Data Model: changed type of 'action' field from 'not_allowed_in_search' to 'required'

2. In Malware Data Model: changed type of 'date' field from 'required' to 'not_allowed_in_search'