### PR TITLE
ACD-4070:Added-dynamic-index-retry-support

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,3 +13,5 @@ python:
   version: 3.7
   install:
     - requirements: docs/requirements.txt
+    - method: pip
+        path: .

--- a/pytest_splunk_addon/standard_lib/fields_tests/test_templates.py
+++ b/pytest_splunk_addon/standard_lib/fields_tests/test_templates.py
@@ -7,9 +7,6 @@ import logging
 import pytest
 from ..addon_parser import Field
 
-INTERVAL = 4
-RETRIES = 4
-
 
 class FieldTestTemplates(object):
     """
@@ -61,8 +58,9 @@ class FieldTestTemplates(object):
         record_property("stanza_type", splunk_searchtime_fields_positive["stanza_type"])
         record_property("fields", splunk_searchtime_fields_positive["fields"])
 
+        index_list = "(index=" + " OR index=".join(splunk_search_util.search_index.split(',')) + ")"
         search = (
-            f"search (index=_internal OR index=*)"
+            f"search {index_list}"
             f" {splunk_searchtime_fields_positive['stanza_type']}=\""
             f"{splunk_searchtime_fields_positive['stanza']}\""
         )
@@ -81,13 +79,13 @@ class FieldTestTemplates(object):
 
         # run search
         result = splunk_search_util.checkQueryCountIsGreaterThanZero(
-            search, interval=INTERVAL, retries=RETRIES
+            search, interval=splunk_search_util.search_interval, retries=splunk_search_util.search_retry
         )
         record_property("search", search)
 
         assert result, (
             f"No result found for the search.\nsearch={search}\n"
-            f"interval={INTERVAL}, retries={RETRIES}"
+            f"interval={splunk_search_util.search_interval}, retries={splunk_search_util.search_retry}"
         )
 
     @pytest.mark.splunk_searchtime_fields
@@ -114,8 +112,9 @@ class FieldTestTemplates(object):
         record_property("stanza_type", splunk_searchtime_fields_negative["stanza_type"])
         record_property("fields", splunk_searchtime_fields_negative["fields"])
 
+        index_list = "(index=" + " OR index=".join(splunk_search_util.search_index.split(',')) + ")"
         search = (
-            f"search (index=_internal OR index=*)"
+            f"search {index_list}"
             f" {splunk_searchtime_fields_negative['stanza_type']}=\""
             f"{splunk_searchtime_fields_negative['stanza']}\""
         )
@@ -171,13 +170,14 @@ class FieldTestTemplates(object):
         record_property("tag", tag)
         record_property("is_tag_enabled", is_tag_enabled)
 
-        search = f"search (index=* OR index=_internal) {tag_query} AND tag={tag}"
+        index_list = "(index=" + " OR index=".join(splunk_search_util.search_index.split(',')) + ")"
+        search = f"search {index_list} {tag_query} AND tag={tag}"
         search += " | stats count by sourcetype"
 
         self.logger.info(f"Search: {search}")
 
         result = splunk_search_util.checkQueryCountIsGreaterThanZero(
-            search, interval=INTERVAL, retries=RETRIES
+            search, interval=splunk_search_util.search_interval, retries=splunk_search_util.search_retry
         )
 
         record_property("search", search)
@@ -186,13 +186,13 @@ class FieldTestTemplates(object):
             assert result, (
                 f"No events found for the enabled Tag={tag}."
                 f"\nsearch={search}"
-                f"\ninterval={INTERVAL}, retries={RETRIES}"
+                f"\ninterval={splunk_search_util.search_interval}, retries={splunk_search_util.search_retry}"
             )
         else:
             assert not result, (
                 f"Events found for the disabled Tag={tag}."
                 f"\nsearch={search}"
-                f"\ninterval={INTERVAL}, retries={RETRIES}"
+                f"\ninterval={splunk_search_util.search_interval}, retries={splunk_search_util.search_retry}"
             )
 
     @pytest.mark.splunk_searchtime_fields
@@ -221,7 +221,8 @@ class FieldTestTemplates(object):
         record_property(
             "eventtype", splunk_searchtime_fields_eventtypes["stanza"]
         )
-        search = (f"search (index=_internal OR index=*) AND "
+        index_list = "(index=" + " OR index=".join(splunk_search_util.search_index.split(',')) + ")"
+        search = (f"search {index_list} AND "
                   f"eventtype="
                   f"\"{splunk_searchtime_fields_eventtypes['stanza']}\"")
         search += " | stats count by sourcetype"
@@ -234,10 +235,10 @@ class FieldTestTemplates(object):
 
         # run search
         result = splunk_search_util.checkQueryCountIsGreaterThanZero(
-            search, interval=INTERVAL, retries=RETRIES
+            search, interval=splunk_search_util.search_interval, retries=splunk_search_util.search_retry
         )
         record_property("search", search)
         assert result, (
             f"No result found for the search.\nsearch={search}\n"
-            f"interval={INTERVAL}, retries={RETRIES}"
+            f"interval={splunk_search_util.search_interval}, retries={splunk_search_util.search_retry}"
         )

--- a/tests/test_splunk_addon.py
+++ b/tests/test_splunk_addon.py
@@ -129,7 +129,7 @@ def test_splunk_app_fiction(testdir):
     setup_test_dir(testdir)
     # run pytest with the following cmd args
     result = testdir.runpytest(
-        "--splunk-type=docker",  "-v", "-m splunk_searchtime_fields",
+        "--splunk-type=docker",  "-v", "-m splunk_searchtime_fields","--search-interval=4","--search-retry=4",
     )
 
     result.stdout.fnmatch_lines_random(constants.TA_FICTION_PASSED)
@@ -161,7 +161,7 @@ def test_splunk_app_broken(testdir):
 
     # run pytest with the following cmd args
     result = testdir.runpytest(
-        "--splunk-type=docker",  "-v", "-m splunk_searchtime_fields",
+        "--splunk-type=docker",  "-v", "-m splunk_searchtime_fields","--search-interval=4","--search-retry=4",
     )
 
     # fnmatch_lines does an assertion internally
@@ -208,6 +208,8 @@ def test_splunk_app_cim_fiction(testdir):
         "--splunk-dm-path=tests/data_models",
         "-v",
         "-m splunk_searchtime_cim",
+        "--search-interval=4",
+        "--search-retry=4",
     )
 
     result.stdout.fnmatch_lines_random(constants.TA_CIM_FICTION_PASSED)
@@ -247,7 +249,9 @@ def test_splunk_app_cim_broken(testdir):
         "--splunk-type=docker",
         "--splunk-dm-path=tests/data_models",
         "-v",
-        "-m splunk_searchtime_cim"
+        "-m splunk_searchtime_cim",
+        "--search-interval=4",
+        "--search-retry=4",
     )
 
     # fnmatch_lines does an assertion internally
@@ -288,7 +292,7 @@ def test_splunk_setup_fixture(testdir):
         )
 
     result = testdir.runpytest(
-        "--splunk-type=docker",  "-v", "-k saved_search_lookup",
+        "--splunk-type=docker",  "-v", "-k saved_search_lookup","--search-interval=4","--search-retry=4",
     )
 
     result.assert_outcomes(


### PR DESCRIPTION
- Implemented Dynamic Index, Interval, and Retry support for the plugin.

- User can provide index name as **search-index** , interval as **search-interval** ,retry as **search-retry** in args 