### PR TITLE
ACD-4070:Added-doc-support

### DIFF
--- a/docs/field_tests.rst
+++ b/docs/field_tests.rst
@@ -130,6 +130,7 @@ In the case of test-case failure check if:
 
     - The add-on to be tested is installed on the Splunk instance.
     - Data is generated sufficiently for the add-on being tested.
+    - Data is generated sufficiently in the specific index, it is being tested.
     - Splunk licence has not expired.
     - Splunk instance is up and running.
     - Splunk instance's management port is accessible from the test machine.

--- a/docs/how_to_use.rst
+++ b/docs/how_to_use.rst
@@ -80,6 +80,31 @@ There are 2 types of tests included in pytest-splunk-addon.
 
             -m  splunk_searchtime_cim
 
+----------------------
+
+There are some optional arguments for pytest-splunk-addon
+
+    1. To search for events in a specific index, user can provide following additional arguments:
+
+        .. code-block:: console
+
+            --search-index=<index>
+
+                Splunk index of which the events will be searched while testing. Default value: "*, _internal".
+
+
+    2. To increase/decrease time interval and retries for flaky tests, user can provide following additional arguments:
+
+        .. code-block:: console
+
+            --search-retry=<retry>
+
+                Number of retries to make if there are no events found while searching in the Splunk instance. Default value: 3.
+
+            --search-interval=<interval>
+
+                Time interval to wait before retrying the search query.Default value: 3.
+
 
 Extending pytest-splunk-addon
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/how_to_use.rst
+++ b/docs/how_to_use.rst
@@ -82,7 +82,7 @@ There are 2 types of tests included in pytest-splunk-addon.
 
 ----------------------
 
-There are some optional arguments for pytest-splunk-addon
+The following optional arguments are available to modify the default settings in the test cases.
 
     1. To search for events in a specific index, user can provide following additional arguments:
 


### PR DESCRIPTION
- Added documentation details for additional arguments in pytest-splunk-addon.
![image](https://user-images.githubusercontent.com/62132597/82420754-cb535300-9a9d-11ea-9dda-4ba20dc928bf.png)
