### PR TITLE
ACD-4278: validation of object_category field updated in Change data-model

### DIFF
--- a/pytest_splunk_addon/standard_lib/data_models/Change.json
+++ b/pytest_splunk_addon/standard_lib/data_models/Change.json
@@ -57,7 +57,7 @@
         {
           "name": "object_category",
           "type": "required",
-          "validity": "if(match(object_category,\"^\\S+$\"),object_category,null())",
+          "validity": "if(match(object_category,\"^[a-z_]+$\"),object_category,null())",
           "comment": "Generic name for the class of the updated resource object. Expected values may be specific to an app."
         },
         {

--- a/pytest_splunk_addon/standard_lib/data_models/Change.json
+++ b/pytest_splunk_addon/standard_lib/data_models/Change.json
@@ -57,7 +57,7 @@
         {
           "name": "object_category",
           "type": "required",
-          "expected_values": ["registry", "directory", "file", "group", "user"],
+          "validity": "if(match(object_category,\"^\\S+$\"),object_category,null())",
           "comment": "Generic name for the class of the updated resource object. Expected values may be specific to an app."
         },
         {


### PR DESCRIPTION
As part of this JIRA, updated the Change.json DataModel "object_category" field with validation of accepting a single value in the event with no space.
For Example:

- The field can accept values like "registry_one", "win_eventlog".

- The field must not have values like "win eventlog", "res one".