### PR TITLE
Acd-4275 IDS Data Model Changes

### DIFF
--- a/pytest_splunk_addon/standard_lib/cim_tests/field_test_helper.py
+++ b/pytest_splunk_addon/standard_lib/cim_tests/field_test_helper.py
@@ -132,7 +132,7 @@ class FieldTestHelper(object):
         return self.parsed_result
 
     def _gen_condition(self):
-        return " AND ".join(
+        return " OR ".join(
             [each_field.condition for each_field in self.fields if each_field.condition]
         )
 

--- a/pytest_splunk_addon/standard_lib/data_models/Intrusion_Detection.json
+++ b/pytest_splunk_addon/standard_lib/data_models/Intrusion_Detection.json
@@ -5,7 +5,7 @@
     {
       "name": "IDS_Attacks",
       "tags": [["ids", "attack"]],
-      "fields_cluster": [],
+      "fields_cluster": [["bytes", "bytes_in", "bytes_out"]],
       "search_constraints": "tag=ids tag=attack",
       "fields": [
         {
@@ -13,6 +13,27 @@
           "type": "required",
           "expected_values": ["allowed", "blocked"],
           "comment": "The action performed on the resource."
+        },
+        {
+          "name": "bytes",
+          "type": "conditional",
+          "condition": "isnum(bytes_out) and isnum(bytes_in)",
+          "validity": "if(isnum(bytes))",
+          "comment": "Total count of bytes handled by this device/interface (bytes_in + bytes_out)."
+        },
+        {
+          "name": "bytes_in",
+          "type": "conditional",
+          "condition": "isnum(bytes_out)",
+          "validity": "if(isnum(bytes_in))",
+          "comment": "How many bytes this device/interface received."
+        },
+        {
+          "name": "bytes_out",
+          "type": "conditional",
+          "condition": "isnum(bytes_in)",
+          "validity": "if(isnum(bytes_out))",
+          "comment": "How many bytes this device/interface transmitted."
         },
         {
           "name": "category",

--- a/pytest_splunk_addon/standard_lib/data_models/Intrusion_Detection.json
+++ b/pytest_splunk_addon/standard_lib/data_models/Intrusion_Detection.json
@@ -16,22 +16,21 @@
         },
         {
           "name": "bytes",
-          "type": "conditional",
-          "condition": "isnum(bytes_out) and isnum(bytes_in)",
+          "type": "optional",
           "validity": "if(isnum(bytes))",
           "comment": "Total count of bytes handled by this device/interface (bytes_in + bytes_out)."
         },
         {
           "name": "bytes_in",
           "type": "conditional",
-          "condition": "isnum(bytes_out)",
+          "condition": "bytes_in=* AND bytes_out=*",
           "validity": "if(isnum(bytes_in))",
           "comment": "How many bytes this device/interface received."
         },
         {
           "name": "bytes_out",
           "type": "conditional",
-          "condition": "isnum(bytes_in)",
+          "condition": "bytes_in=* AND bytes_out=*",
           "validity": "if(isnum(bytes_out))",
           "comment": "How many bytes this device/interface transmitted."
         },

--- a/pytest_splunk_addon/standard_lib/data_models/Intrusion_Detection.json
+++ b/pytest_splunk_addon/standard_lib/data_models/Intrusion_Detection.json
@@ -5,7 +5,7 @@
     {
       "name": "IDS_Attacks",
       "tags": [["ids", "attack"]],
-      "fields_cluster": [["bytes", "bytes_in", "bytes_out"]],
+      "fields_cluster": [],
       "search_constraints": "tag=ids tag=attack",
       "fields": [
         {

--- a/pytest_splunk_addon/standard_lib/data_models/Intrusion_Detection.json
+++ b/pytest_splunk_addon/standard_lib/data_models/Intrusion_Detection.json
@@ -5,7 +5,7 @@
     {
       "name": "IDS_Attacks",
       "tags": [["ids", "attack"]],
-      "fields_cluster": [],
+      "fields_cluster": [["bytes_in", "bytes_out"]],
       "search_constraints": "tag=ids tag=attack",
       "fields": [
         {
@@ -16,21 +16,22 @@
         },
         {
           "name": "bytes",
-          "type": "optional",
+          "type": "conditional",
+          "condition": "bytes_in=* OR bytes_out=*",
           "validity": "if(isnum(bytes))",
           "comment": "Total count of bytes handled by this device/interface (bytes_in + bytes_out)."
         },
         {
           "name": "bytes_in",
           "type": "conditional",
-          "condition": "bytes_in=* AND bytes_out=*",
+          "condition": "bytes_in=*",
           "validity": "if(isnum(bytes_in))",
           "comment": "How many bytes this device/interface received."
         },
         {
           "name": "bytes_out",
           "type": "conditional",
-          "condition": "bytes_in=* AND bytes_out=*",
+          "condition": "bytes_out=*",
           "validity": "if(isnum(bytes_out))",
           "comment": "How many bytes this device/interface transmitted."
         },

--- a/pytest_splunk_addon/standard_lib/data_models/Intrusion_Detection.json
+++ b/pytest_splunk_addon/standard_lib/data_models/Intrusion_Detection.json
@@ -18,21 +18,21 @@
           "name": "bytes",
           "type": "conditional",
           "condition": "bytes_in=* OR bytes_out=*",
-          "validity": "if(isnum(bytes))",
+          "validity": "if(isnum(bytes), bytes, null())",
           "comment": "Total count of bytes handled by this device/interface (bytes_in + bytes_out)."
         },
         {
           "name": "bytes_in",
           "type": "conditional",
           "condition": "bytes_in=*",
-          "validity": "if(isnum(bytes_in))",
+          "validity": "if(isnum(bytes_in), bytes_in, null())",
           "comment": "How many bytes this device/interface received."
         },
         {
           "name": "bytes_out",
           "type": "conditional",
           "condition": "bytes_out=*",
-          "validity": "if(isnum(bytes_out))",
+          "validity": "if(isnum(bytes_out), bytes_out, null())",
           "comment": "How many bytes this device/interface transmitted."
         },
         {


### PR DESCRIPTION
As a part of this PR, the following has been implemented:

1.  3 new fields have been added to the **Intrusion Detection** data model: **bytes, bytes_in, bytes_out**. The description of the fields is as below:

**bytes:** The field is required, if both bytes_in or bytes_out are present in the event.
**bytes_out:** The field is required, if bytes_in is present in the event.

     
     



