### PR TITLE
Acd 4285 Add Description in CIM compliance report

### DIFF
--- a/pytest_splunk_addon/standard_lib/cim_compliance/base_report.py
+++ b/pytest_splunk_addon/standard_lib/cim_compliance/base_report.py
@@ -15,6 +15,10 @@ class CIMReport(abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
+    def add_section_description(self, string):
+        raise NotImplementedError()
+
+    @abc.abstractmethod
     def add_section_note(self, string):
         raise NotImplementedError()
 

--- a/pytest_splunk_addon/standard_lib/cim_compliance/ca_report_generator.py
+++ b/pytest_splunk_addon/standard_lib/cim_compliance/ca_report_generator.py
@@ -152,6 +152,7 @@ class CIMReportGenerator(object):
         # Generating Summary table.
 
         self.report_generator.add_section_title(" Summary")
+        self.report_generator.add_section_description("Displays test case summary of the add-on for all the supported data models.")
         summary_table = MarkdownTable("", ["Data Model", "Status", "Fail/Total"])
         data_models = iter(SUPPORTED_DATAMODELS)
 
@@ -170,6 +171,7 @@ class CIMReportGenerator(object):
 
         # Generating Tag Stanza Mapping table.
         self.report_generator.add_section_title("Tag Stanza Mapping")
+        self.report_generator.add_section_description("Displays test case summary for the stanzas in tags.conf and the dataset mapped with it.")
         tag_stanza_map = MarkdownTable("", ["Tag Stanza", "Data Set", "Fail/Total"])
         for group, stats in self._get_count_by(["data_set", "tag_stanza"]):
             data_set, tag_stanza = group
@@ -179,6 +181,7 @@ class CIMReportGenerator(object):
 
         # Generating Field Summary tables.
         self.report_generator.add_section_title("Field Summary")
+        self.report_generator.add_section_description("Displays test case summary for all the fields in the dataset for the tag-stanza it is mapped with.")
 
         for group_name, grouped_data in self._group_by(["tag_stanza", "data_set"]):
             field_summary_table = MarkdownTable(

--- a/pytest_splunk_addon/standard_lib/cim_compliance/junit_parser.py
+++ b/pytest_splunk_addon/standard_lib/cim_compliance/junit_parser.py
@@ -56,7 +56,11 @@ class JunitParser(object):
         else:
             status = "passed"
 
-        skip_type = "-" if not status == "skipped" else testcase.result.type
+        test_property = (
+            "-"
+            if not status == "failed"
+            else testcase.result.message.splitlines()[0][:100]
+        )
         row_template = {
             "data_model": None,
             "data_set": None,
@@ -64,7 +68,7 @@ class JunitParser(object):
             "status": status,
             "tag_stanza": None,
             "fields_type": None,
-            "skip_type": skip_type,
+            "test_property": test_property,
         }
         props = self.yield_properties(testcase)
         try:

--- a/pytest_splunk_addon/standard_lib/cim_compliance/junit_parser.py
+++ b/pytest_splunk_addon/standard_lib/cim_compliance/junit_parser.py
@@ -6,6 +6,7 @@ import argparse
 import errno
 import os
 import sys
+from html import escape, unescape
 from junitparser import JUnitXml, Properties
 
 
@@ -59,7 +60,7 @@ class JunitParser(object):
         test_property = (
             "-"
             if not status == "failed"
-            else testcase.result.message.splitlines()[0][:100]
+            else escape(unescape(testcase.result.message.splitlines()[0])[:100])
         )
         row_template = {
             "data_model": None,

--- a/pytest_splunk_addon/standard_lib/cim_compliance/markdown_report.py
+++ b/pytest_splunk_addon/standard_lib/cim_compliance/markdown_report.py
@@ -27,6 +27,15 @@ class MarkDownReport(CIMReport):
         """
         self.markdown_str += "\n## {}\n".format(section_title)
 
+    def add_section_description(self, description):
+        """
+        Adds description string to the section
+
+        Args:
+            description(str): Description string.
+        """
+        self.markdown_str += "\n**Description:** " + description + "\n"
+
     def add_section_note(self, section_note):
         """
         Function to set Note in a report


### PR DESCRIPTION
Added 'add_section_description method' for the markdown_report module.
Added description for the tables generated in the report to make the report more intuitive.