### PR TITLE
ACD-4305: Updated search query for cim test cases for clustered fields

### DIFF
--- a/pytest_splunk_addon/standard_lib/cim_tests/field_test_helper.py
+++ b/pytest_splunk_addon/standard_lib/cim_tests/field_test_helper.py
@@ -132,7 +132,7 @@ class FieldTestHelper(object):
         return self.parsed_result
 
     def _gen_condition(self):
-        return " AND ".join(
+        return " OR ".join(
             [each_field.condition for each_field in self.fields if each_field.condition]
         )
 


### PR DESCRIPTION
Replaced 'AND' condition to 'OR' condition in search query CIM test cases for clustered fields