### PR TITLE
Bugfix/acd 4276 port required only if transport tcp udp

### DIFF
--- a/pytest_splunk_addon/standard_lib/data_models/Intrusion_Detection.json
+++ b/pytest_splunk_addon/standard_lib/data_models/Intrusion_Detection.json
@@ -83,6 +83,20 @@
           "comment": "The OSI layer 4 (transport) protocol of the intrusion, in lower case."
         },
         {
+          "name": "src_port",
+          "type": "conditional",
+          "condition": "transport=tcp OR transport=udp",
+          "validity": "if(isnum(src_port),src_port,null())",
+          "comment": "The source port of the network traffic. Note: Do not translate the value of this field to a string (tcp/80 is 80, not http). You can set up the corresponding string value in the src_svc field."
+        },
+        {
+          "name": "dest_port",
+          "type": "conditional",
+          "condition": "transport=tcp OR transport=udp",
+          "validity": "if(isnum(dest_port),dest_port,null())",
+          "comment": "The destination port of the network traffic. Note: Do not translate the value of this field to a string (tcp/80 is 80, not http). You can set up the corresponding string value in the dest_svc field."
+        },
+        {
           "name": "user",
           "type": "conditional",
           "condition": "ids_type!=\"host\"",

--- a/pytest_splunk_addon/standard_lib/data_models/Intrusion_Detection.json
+++ b/pytest_splunk_addon/standard_lib/data_models/Intrusion_Detection.json
@@ -87,14 +87,14 @@
           "type": "conditional",
           "condition": "transport=tcp OR transport=udp",
           "validity": "if(isnum(src_port),src_port,null())",
-          "comment": "The source port of the network traffic. Note: Do not translate the value of this field to a string (tcp/80 is 80, not http). You can set up the corresponding string value in the src_svc field."
+          "comment": "The source port of the intrusion detection. Note: Do not translate the value of this field to a string (tcp/80 is 80, not http). You can set up the corresponding string value in the src_svc field."
         },
         {
           "name": "dest_port",
           "type": "conditional",
           "condition": "transport=tcp OR transport=udp",
           "validity": "if(isnum(dest_port),dest_port,null())",
-          "comment": "The destination port of the network traffic. Note: Do not translate the value of this field to a string (tcp/80 is 80, not http). You can set up the corresponding string value in the dest_svc field."
+          "comment": "The destination port of the intrusion detection. Note: Do not translate the value of this field to a string (tcp/80 is 80, not http). You can set up the corresponding string value in the dest_svc field."
         },
         {
           "name": "user",

--- a/pytest_splunk_addon/standard_lib/data_models/Network_Traffic.json
+++ b/pytest_splunk_addon/standard_lib/data_models/Network_Traffic.json
@@ -75,7 +75,7 @@
         {
           "name": "dest_port",
           "type": "conditional",
-          "condition": "protocol=ip",
+          "condition": "transport=tcp OR transport=udp",
           "validity": "if(isnum(dest_port),dest_port,null())",
           "comment": "The destination port of the network traffic. Note: Do not translate the value of this field to a string (tcp/80 is 80, not http). You can set up the corresponding string value in the dest_svc field."
         },
@@ -88,7 +88,7 @@
         {
           "name": "dest_translated_port",
           "type": "conditional",
-          "condition": "protocol=ip AND dest_translated_ip=*",
+          "condition": "(transport=tcp OR transport=udp) AND dest_translated_ip=*",
           "comment": "The NATed port to which a packet has been sent. Note: Do not translate the values of this field to strings (tcp/80 is 80, not http)."
         },
         {
@@ -132,6 +132,7 @@
           "name": "icmp_code",
           "type": "conditional",
           "condition": "protocol=icmp",
+          "validity": "if(isnum(icmp_code),icmp_code,null())",
           "comment": "The RFC 2780 or RFC 4443 human-readable code value of the traffic, such as Destination Unreachable or Parameter Problem . See the ICMP Type Numbers and the ICMPv6 Type Numbers."
         },
         {
@@ -275,14 +276,14 @@
         {
           "name": "src_port",
           "type": "conditional",
-          "condition": "protocol=ip",
+          "condition": "transport=tcp OR transport=udp",
           "validity": "if(isnum(src_port),src_port,null())",
           "comment": "The source port of the network traffic. Note: Do not translate the value of this field to a string (tcp/80 is 80, not http). You can set up the corresponding string value in the src_svc field."
         },
         {
           "name": "src_translated_port",
           "type": "conditional",
-          "condition": "protocol=ip AND src_translated_ip=*",
+          "condition": "(transport=tcp OR transport=udp) AND src_translated_ip=*",
           "validity": "if(isnum(src_translated_port),src_translated_port,null())",
           "comment": "The NATed port from which a packet has been sent. Note: Do not translate the values of this field to strings (tcp/80 is 80, not http."
         }


### PR DESCRIPTION
- Updated the Intrusion Detection DM to added the src_port and dest_port field
- Updated the Network Traffic data model with below changes

> 1. Replaced the `protocol=ip` condition value to 'transport=tcp OR transport=udp' for dest_port, dest_translated_port, src_port and src_translated_port field
> 2. Added the validity for icmp_code field to it's must be a number value