### PR TITLE
Acd 4383 bytes bytes in byte out are optional on network data model

### DIFF
--- a/pytest_splunk_addon/standard_lib/data_models/Network_Traffic.json
+++ b/pytest_splunk_addon/standard_lib/data_models/Network_Traffic.json
@@ -32,14 +32,14 @@
         },
         {
           "name": "bytes_in",
-          "type": "required",
-          "validity": "if(isnum(bytes_in),bytes_in,null())",
+          "type": "optional",
+          "validity": "if(isnum(bytes_in) and bytes_in>0,bytes_in,null())",
           "comment": "How many bytes this device/interface received."
         },
         {
           "name": "bytes_out",
-          "type": "required",
-          "validity": "if(isnum(bytes_out),bytes_out,null())",
+          "type": "optional",
+          "validity": "if(isnum(bytes_out) and bytes_out>0,bytes_out,null())",
           "comment": "How many bytes this device/interface transmitted."
         },
         {

--- a/pytest_splunk_addon/standard_lib/data_models/Network_Traffic.json
+++ b/pytest_splunk_addon/standard_lib/data_models/Network_Traffic.json
@@ -27,7 +27,7 @@
         {
           "name": "bytes",
           "type": "optional",
-          "validity": "if(isnum(bytes) and bytes==(bytes_in+bytes_out),bytes,null())",
+          "validity": "if(isnum(bytes) and bytes>0 and bytes==(bytes_in+bytes_out),bytes,null())",
           "comment": "Total count of bytes handled by this device/interface (bytes_in + bytes_out)."
         },
         {

--- a/pytest_splunk_addon/standard_lib/data_models/Network_Traffic.json
+++ b/pytest_splunk_addon/standard_lib/data_models/Network_Traffic.json
@@ -26,7 +26,7 @@
         },
         {
           "name": "bytes",
-          "type": "required",
+          "type": "optional",
           "validity": "if(isnum(bytes) and bytes==(bytes_in+bytes_out),bytes,null())",
           "comment": "Total count of bytes handled by this device/interface (bytes_in + bytes_out)."
         },


### PR DESCRIPTION
Changed the fields bytes, bytes_in, and bytes_out for Network_traffix data model, and changed their validity so that they are not 0. 