### PR TITLE
Acd 4382 network traffic packets fields are not required

### DIFF
--- a/pytest_splunk_addon/standard_lib/data_models/Network_Traffic.json
+++ b/pytest_splunk_addon/standard_lib/data_models/Network_Traffic.json
@@ -26,20 +26,20 @@
         },
         {
           "name": "bytes",
-          "type": "optional",
-          "validity": "if(isnum(bytes) and bytes>0 and bytes==(bytes_in+bytes_out),bytes,null())",
+          "type": "required",
+          "validity": "if(isnum(bytes) and bytes==(bytes_in+bytes_out),bytes,null())",
           "comment": "Total count of bytes handled by this device/interface (bytes_in + bytes_out)."
         },
         {
           "name": "bytes_in",
-          "type": "optional",
-          "validity": "if(isnum(bytes_in) and bytes_in>0,bytes_in,null())",
+          "type": "required",
+          "validity": "if(isnum(bytes_in),bytes_in,null())",
           "comment": "How many bytes this device/interface received."
         },
         {
           "name": "bytes_out",
-          "type": "optional",
-          "validity": "if(isnum(bytes_out) and bytes_out>0,bytes_out,null())",
+          "type": "required",
+          "validity": "if(isnum(bytes_out),bytes_out,null())",
           "comment": "How many bytes this device/interface transmitted."
         },
         {

--- a/pytest_splunk_addon/standard_lib/data_models/Network_Traffic.json
+++ b/pytest_splunk_addon/standard_lib/data_models/Network_Traffic.json
@@ -26,20 +26,20 @@
         },
         {
           "name": "bytes",
-          "type": "required",
-          "validity": "if(isnum(bytes) and bytes==(bytes_in+bytes_out),bytes,null())",
+          "type": "optional",
+          "validity": "if(isnum(bytes) and bytes>0 and bytes==(bytes_in+bytes_out),bytes,null())",
           "comment": "Total count of bytes handled by this device/interface (bytes_in + bytes_out)."
         },
         {
           "name": "bytes_in",
-          "type": "required",
-          "validity": "if(isnum(bytes_in),bytes_in,null())",
+          "type": "optional",
+          "validity": "if(isnum(bytes_in) and bytes_in>0,bytes_in,null())",
           "comment": "How many bytes this device/interface received."
         },
         {
           "name": "bytes_out",
-          "type": "required",
-          "validity": "if(isnum(bytes_out),bytes_out,null())",
+          "type": "optional",
+          "validity": "if(isnum(bytes_out) and bytes_out>0,bytes_out,null())",
           "comment": "How many bytes this device/interface transmitted."
         },
         {

--- a/pytest_splunk_addon/standard_lib/data_models/Network_Traffic.json
+++ b/pytest_splunk_addon/standard_lib/data_models/Network_Traffic.json
@@ -145,7 +145,7 @@
         {
           "name": "packets",
           "type": "conditional",
-          "condition": "packets_in=* and packets_out=*",
+          "condition": "packets_in=* AND packets_out=*",
           "validity": "if(isnum(packets),packets,null())",
           "comment": "The total count of packets handled by this device/interface (packets_in + packets_out)."
         },

--- a/pytest_splunk_addon/standard_lib/data_models/Network_Traffic.json
+++ b/pytest_splunk_addon/standard_lib/data_models/Network_Traffic.json
@@ -144,19 +144,22 @@
         },
         {
           "name": "packets",
-          "type": "required",
-          "validity": "if(isnum(packets) and packets==packets_in+packets_out,packets,null())",
+          "type": "conditional",
+          "condition": "packets_in=* and packets_out=*",
+          "validity": "if(isnum(packets),packets,null())",
           "comment": "The total count of packets handled by this device/interface (packets_in + packets_out)."
         },
         {
           "name": "packets_in",
-          "type": "required",
+          "type": "conditional",
+          "condition": "packets_out=*",
           "validity": "if(isnum(packets_in),packets_in,null())",
           "comment": "The total count of packets received by this device/interface."
         },
         {
           "name": "packets_out",
-          "type": "required",
+          "type": "conditional",
+          "condition": "packets_in=*",
           "validity": "if(isnum(packets_out),packets_out,null())",
           "comment": "The total count of packets transmitted by this device/interface."
         },


### PR DESCRIPTION
Changed packets field to be conditional fields, depending on the availability of the other fields present as part of ACD-3482 for the Network_traffc data model.