### PR TITLE
Minor fixes for sample generation

### DIFF
--- a/pytest_splunk_addon/standard_lib/sample_generation/rule.py
+++ b/pytest_splunk_addon/standard_lib/sample_generation/rule.py
@@ -68,7 +68,8 @@ class Rule:
             "dvc": DvcRule,
             "guid": GuidRule
         }
-
+        rule_all_support = ["integer", "list", "file"]
+        
         replacement_type = token["replacementType"]
         replacement = token["replacement"]
         if replacement_type == "static":
@@ -78,6 +79,10 @@ class Rule:
         elif replacement_type == "random" or replacement_type == "all":
             for each_rule in rule_book:
                 if replacement.lower().startswith(each_rule):
+                    if replacement_type == "all" and each_rule not in rule_all_support:
+                        token["replacementType"] = "random"
+                        LOGGER.warning("replacement_type=all is not supported for {} rule applied to {} token.".format(each_rule, token.get("token")))
+                        warnings.warn(UserWarning("replacement_type=all is not supported for {} rule applied to {} token.".format(each_rule, token.get("token"))))
                     return rule_book[each_rule](token, sample_path=sample_path)
         elif replacement_type == "file" or replacement_type == "mvfile":
             return FileRule(token, sample_path=sample_path)

--- a/pytest_splunk_addon/standard_lib/sample_generation/sample_generator.py
+++ b/pytest_splunk_addon/standard_lib/sample_generation/sample_generator.py
@@ -29,7 +29,7 @@ class SampleGenerator(object):
         if not SampleGenerator.sample_stanzas:
             eventgen_parser = EventgenParser(self.addon_path)
             SampleGenerator.sample_stanzas = list(eventgen_parser.get_sample_stanzas())
-            with ThreadPoolExecutor(min(20, len(SampleGenerator.sample_stanzas))) as t:
+            with ThreadPoolExecutor(min(20, max(len(SampleGenerator.sample_stanzas), 1))) as t:
                 t.map(SampleStanza.get_raw_events, SampleGenerator.sample_stanzas)
             # with ProcessPoolExecutor(self.process_count) as p:
             _ = list(map(SampleStanza.tokenize, SampleGenerator.sample_stanzas))


### PR DESCRIPTION

-   Added warning in console if replacementtype=all not supported for token rule.
i.e. `replacement_type=all is not supported for user rule applied to ##token_user_name## token.`

-  Added warning if a sample file is not found for a stanza in the eventgen.conf
i.e. `No sample file found for stanza : sample_file_two12.samples`