### PR TITLE
Feature/acd 4442 support both confs

### DIFF
--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -17,7 +17,6 @@ from .helmut.manager.jobs import Jobs
 from .helmut.splunk.cloud import CloudSplunk
 from .helmut_lib.SearchUtil import SearchUtil
 from .standard_lib.event_ingestors import IngestorHelper
-from .standard_lib.sample_generation import SampleGenerator
 import configparser
 
 
@@ -152,6 +151,15 @@ def pytest_addoption(parser):
             "pytest-splunk-addon\pytest_splunk_addon\standard_lib\cim_tests\DatamodelSchema.json"
         ),
     )
+    group.addoption(
+        "--splunk-data-generator",
+        action="store",
+        dest="splunk_data_generator",
+        default="pytest-splunk-addon-sample-generator.conf",
+        help=(
+            "Path to pytest-splunk-addon-sample-generator.conf."
+        ),
+    ) 
     group.addoption(
         "--sc4s-host",
         action="store",
@@ -460,7 +468,7 @@ def splunk_web_uri(splunk):
     return uri
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="class")
 def splunk_ingest_data(request, splunk_hec_uri, sc4s):
     """
     Generates events for the add-on and ingests into Splunk.
@@ -478,7 +486,36 @@ def splunk_ingest_data(request, splunk_hec_uri, sc4s):
     manual configurations are required.
     """
     addon_path = request.config.getoption("splunk_app")
-    sample_generator = SampleGenerator(addon_path)
+    config_path = request.config.getoption("splunk_data_generator")
+
+    ingest_meta_data = {
+        "session_headers": splunk_hec_uri[0].headers,
+        "splunk_hec_uri": splunk_hec_uri[1],
+        "splunk_host": sc4s[0],  # for sc4s
+        "sc4s_port": sc4s[1][514]  # for sc4s
+    }
+    IngestorHelper.ingest_events(ingest_meta_data, addon_path, config_path, False)
+
+
+@pytest.fixture(scope="class")
+def splunk_ingest_bulk_data(request, splunk_hec_uri, sc4s):
+    """
+    Generates events in bulk for the add-on and ingests into Splunk.
+    The ingestion can be done using the following methods:
+        1. HEC Event
+        2. HEC Raw
+        3. SC4S:TCP or SC4S:UDP
+        4. HEC Metrics
+
+    Args:
+    splunk_hec_uri(tuple): Details for hec uri and session headers
+    sc4s(tuple): Details for sc4s server and TCP port
+
+    TODO: For splunk_type=external, data will not be ingested as 
+    manual configurations are required.
+    """
+    addon_path = request.config.getoption("splunk_app")
+    config_path = request.config.getoption("splunk_data_generator")
 
     ingest_meta_data = {
         "session_headers": splunk_hec_uri[0].headers,
@@ -487,19 +524,7 @@ def splunk_ingest_data(request, splunk_hec_uri, sc4s):
         "sc4s_port": sc4s[1][514]  # for sc4s
     }
 
-    ingestor_dict = dict()
-    for event in sample_generator.get_samples():
-        input_type = event.metadata.get("input_type")
-        if input_type in ingestor_dict:
-            ingestor_dict[input_type].append(event)
-        else:
-            ingestor_dict[input_type] = [event]
-
-    for input_type, events in ingestor_dict.items():
-
-        event_ingestor = IngestorHelper.get_event_ingestor(input_type, ingest_meta_data)
-        event_ingestor.ingest(events)
-
+    IngestorHelper.ingest_events(ingest_meta_data, addon_path, config_path, True)
 
 def is_responsive_splunk(splunk):
     """

--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -494,7 +494,7 @@ def splunk_ingest_data(request, splunk_hec_uri, sc4s):
         "splunk_host": sc4s[0],  # for sc4s
         "sc4s_port": sc4s[1][514]  # for sc4s
     }
-    IngestorHelper.ingest_events(ingest_meta_data, addon_path, config_path, False)
+    IngestorHelper.ingest_events(ingest_meta_data, addon_path, config_path, bulk_event_ingestion=False)
 
 
 @pytest.fixture(scope="class")
@@ -524,7 +524,7 @@ def splunk_ingest_bulk_data(request, splunk_hec_uri, sc4s):
         "sc4s_port": sc4s[1][514]  # for sc4s
     }
 
-    IngestorHelper.ingest_events(ingest_meta_data, addon_path, config_path, True)
+    IngestorHelper.ingest_events(ingest_meta_data, addon_path, config_path, bulk_event_ingestion=True)
 
 def is_responsive_splunk(splunk):
     """

--- a/pytest_splunk_addon/standard_lib/app_test_generator.py
+++ b/pytest_splunk_addon/standard_lib/app_test_generator.py
@@ -71,16 +71,14 @@ class AppTestGenerator(object):
                 self.cim_test_generator.generate_tests(fixture), fixture
             )
         elif fixture.startswith("splunk_indextime_fields"):
-            # TODO: What should be the id of the test case?
-            # Sourcetype + Host + Key field + _count
             addon_path = self.pytest_config.getoption("splunk_app")
-            sample_generator = SampleGenerator(addon_path)
-            assert sample_generator.splunk_test_type == "splunk_indextime"," For indextime testing pytest-splunk-addon-sample-generator.conf is required."
-            pytest_params = list(
-                self.indextime_test_generator.generate_tests(sample_generator.get_samples())
-            )
-
-            yield from sorted(pytest_params, key=lambda param: param.id)
+            config_path = self.pytest_config.getoption("splunk_data_generator")
+            sample_generator = SampleGenerator(addon_path, config_path, bulk_event_ingestion = False)
+            if sample_generator.splunk_test_type == "splunk_indextime":
+                pytest_params = list(
+                    self.indextime_test_generator.generate_tests(sample_generator.get_samples())
+                )
+                yield from sorted(pytest_params, key=lambda param: param.id)
 
     def dedup_tests(self, test_list, fixture):
         """

--- a/pytest_splunk_addon/standard_lib/app_test_generator.py
+++ b/pytest_splunk_addon/standard_lib/app_test_generator.py
@@ -75,7 +75,7 @@ class AppTestGenerator(object):
             # Sourcetype + Host + Key field + _count
             addon_path = self.pytest_config.getoption("splunk_app")
             sample_generator = SampleGenerator(addon_path)
-
+            assert sample_generator.splunk_test_type == "splunk_indextime"," For indextime testing pytest-splunk-addon-sample-generator.conf is required."
             pytest_params = list(
                 self.indextime_test_generator.generate_tests(sample_generator.get_samples())
             )

--- a/pytest_splunk_addon/standard_lib/cim_tests/test_templates.py
+++ b/pytest_splunk_addon/standard_lib/cim_tests/test_templates.py
@@ -54,7 +54,7 @@ class CIMTestTemplates(object):
     @pytest.mark.splunk_searchtime_cim
     @pytest.mark.splunk_searchtime_cim_fields
     def test_cim_required_fields(
-        self, splunk_search_util, splunk_searchtime_cim_fields, record_property
+        self, splunk_search_util, splunk_ingest_bulk_data, splunk_searchtime_cim_fields, record_property
     ):
         """
         Test the the required fields in the data models are extracted with valid values.
@@ -156,6 +156,7 @@ class CIMTestTemplates(object):
     def test_cim_fields_not_allowed_in_search(
         self,
         splunk_search_util,
+        splunk_ingest_bulk_data,
         splunk_searchtime_cim_fields_not_allowed_in_search,
         record_property,
     ):
@@ -238,7 +239,7 @@ class CIMTestTemplates(object):
     @pytest.mark.splunk_searchtime_cim
     @pytest.mark.splunk_searchtime_cim_fields_not_allowed_in_props
     def test_cim_fields_not_allowed_in_props(
-        self, splunk_searchtime_cim_fields_not_allowed_in_props, record_property
+        self, splunk_ingest_bulk_data, splunk_searchtime_cim_fields_not_allowed_in_props, record_property
     ):
         result_str = (
             "The field extractions are not allowed in the configuration files"
@@ -264,6 +265,7 @@ class CIMTestTemplates(object):
     def test_eventtype_mapped_multiple_cim_datamodel(
         self,
         splunk_search_util,
+        splunk_ingest_bulk_data,
         splunk_searchtime_cim_mapped_datamodel,
         record_property,
         caplog,

--- a/pytest_splunk_addon/standard_lib/event_ingestors/ingestor_helper.py
+++ b/pytest_splunk_addon/standard_lib/event_ingestors/ingestor_helper.py
@@ -4,13 +4,13 @@ from . import (
     HECMetricEventIngestor,
     SC4SEventIngestor,
 )
-
+from ..sample_generation import SampleGenerator
 
 class IngestorHelper(object):
     """
     Module for helper methods for ingestors.
     """
-    @classmethod
+
     def get_event_ingestor(self, input_type, ingest_meta_data):
         """
         Based on the input_type of the event, it returns an appropriate ingestor.
@@ -28,3 +28,27 @@ class IngestorHelper(object):
 
         ingestor = ingest_methods.get(input_type)(ingest_meta_data)
         return ingestor
+
+    @classmethod
+    def ingest_events(cls, ingest_meta_data, addon_path, config_path, bulk_event_ingestion):
+        """
+        Events are ingested in the splunk.
+        Args:
+            ingest_meta_data(dict): Dictionary of required meta_data.
+            addon_path: Path to Splunk app package.
+            config_path: Path to pytest-splunk-addon-sample-generator.conf.
+            bulk_event_ingestion(bool): Boolean param for bulk event ingestion.
+
+        """
+        sample_generator = SampleGenerator(addon_path, config_path, bulk_event_ingestion=bulk_event_ingestion)
+        ingestor_dict = dict()
+        for event in sample_generator.get_samples():
+            input_type = event.metadata.get("input_type")
+            if input_type in ingestor_dict:
+                ingestor_dict[input_type].append(event)
+            else:
+                ingestor_dict[input_type] = [event]
+        for input_type, events in ingestor_dict.items():
+
+            event_ingestor = cls.get_event_ingestor(input_type, ingest_meta_data)
+            event_ingestor.ingest(events)

--- a/pytest_splunk_addon/standard_lib/event_ingestors/ingestor_helper.py
+++ b/pytest_splunk_addon/standard_lib/event_ingestors/ingestor_helper.py
@@ -10,8 +10,8 @@ class IngestorHelper(object):
     """
     Module for helper methods for ingestors.
     """
-
-    def get_event_ingestor(self, input_type, ingest_meta_data):
+    @classmethod
+    def get_event_ingestor(cls, input_type, ingest_meta_data):
         """
         Based on the input_type of the event, it returns an appropriate ingestor.
         """

--- a/pytest_splunk_addon/standard_lib/fields_tests/test_templates.py
+++ b/pytest_splunk_addon/standard_lib/fields_tests/test_templates.py
@@ -41,7 +41,7 @@ class FieldTestTemplates(object):
     @pytest.mark.splunk_searchtime_fields
     @pytest.mark.splunk_searchtime_fields_positive
     def test_props_fields(
-        self, splunk_search_util, splunk_searchtime_fields_positive, record_property
+        self, splunk_search_util, splunk_ingest_bulk_data, splunk_searchtime_fields_positive, record_property
     ):
         """
         This test case checks that a field value has the expected values.
@@ -91,7 +91,7 @@ class FieldTestTemplates(object):
     @pytest.mark.splunk_searchtime_fields
     @pytest.mark.splunk_searchtime_fields_negative
     def test_props_fields_no_dash_not_empty(
-        self, splunk_search_util, splunk_searchtime_fields_negative, record_property
+        self, splunk_search_util, splunk_ingest_bulk_data, splunk_searchtime_fields_negative, record_property
     ):
         """
         This test case checks negative scenario for the field value.
@@ -145,7 +145,7 @@ class FieldTestTemplates(object):
     @pytest.mark.splunk_searchtime_fields
     @pytest.mark.splunk_searchtime_fields_tags
     def test_tags(
-        self, splunk_search_util, splunk_searchtime_fields_tags, record_property, caplog
+        self, splunk_search_util, splunk_ingest_bulk_data, splunk_searchtime_fields_tags, record_property, caplog
     ):
         """
         Test case to check tags mentioned in tags.conf
@@ -200,6 +200,7 @@ class FieldTestTemplates(object):
     def test_eventtype(
         self,
         splunk_search_util,
+        splunk_ingest_bulk_data,
         splunk_searchtime_fields_eventtypes,
         record_property,
         caplog,

--- a/pytest_splunk_addon/standard_lib/index_tests/test_templates.py
+++ b/pytest_splunk_addon/standard_lib/index_tests/test_templates.py
@@ -6,6 +6,7 @@ class IndexTimeTestTemplate(object):
 
     logger = logging.getLogger("pytest-splunk-addon-tests")
 
+    @pytest.mark.first
     @pytest.mark.splunk_indextime
     def test_index_time_extractions(
         self,

--- a/pytest_splunk_addon/standard_lib/sample_generation/eventgen_parser.py
+++ b/pytest_splunk_addon/standard_lib/sample_generation/eventgen_parser.py
@@ -13,6 +13,8 @@ class EventgenParser:
     """
     This class represents the entire eventgen.conf file and handles parsing mechanism of eventgen and the rules
     """
+    splunk_test_type = " "
+
     def __init__(self, addon_path):
         """
         init method for the class
@@ -22,18 +24,19 @@ class EventgenParser:
         """
         self._app = App(addon_path, python_analyzer_enable=False)
         self._eventgen = None
-        self.path_to_samples = os.path.join(addon_path, "samples")
+        self.addon_path = addon_path
+        self.path_to_samples = os.path.join(addon_path, "package", "samples")
 
     @property
     def eventgen(self):
-        """
-        Returns a dict representation object of eventgen.conf file.
-        """
-        try:
-            if not self._eventgen:
-                self._eventgen = self._app.get_config("eventgen.conf")
+        try:            
+            if os.path.exists(os.path.join(self.addon_path, "tests", "plugin_event_generator", "pytest-splunk-addon-sample-generator.conf")):
+                self._eventgen = self._app.get_config("pytest-splunk-addon-sample-generator.conf", dir = os.path.join("..", "tests", "plugin_event_generator"))
+                self.splunk_test_type = "splunk_indextime"
+            else:
+                self._eventgen = self._app.get_config("eventgen.conf", dir = "default")    
+                self.splunk_test_type = "splunk_searchtime"
             return self._eventgen
-        # TODO: Update conf file from eventgen.conf to pytest-splunk-addon-data-generator.conf
         except OSError:
             LOGGER.warning("eventgen.conf not found.")
             raise Exception("Eventgen.conf not found")

--- a/pytest_splunk_addon/standard_lib/sample_generation/sample_generator.py
+++ b/pytest_splunk_addon/standard_lib/sample_generation/sample_generator.py
@@ -10,6 +10,7 @@ class SampleGenerator(object):
     Generate sample objects 
     """
     sample_stanzas = []
+    splunk_test_type = " "
     
     def __init__(self, addon_path, process_count=4):
         """
@@ -29,6 +30,7 @@ class SampleGenerator(object):
         if not SampleGenerator.sample_stanzas:
             eventgen_parser = EventgenParser(self.addon_path)
             SampleGenerator.sample_stanzas = list(eventgen_parser.get_sample_stanzas())
+            self.splunk_test_type = eventgen_parser.splunk_test_type
             with ThreadPoolExecutor(min(20, len(SampleGenerator.sample_stanzas))) as t:
                 t.map(SampleStanza.get_raw_events, SampleGenerator.sample_stanzas)
             # with ProcessPoolExecutor(self.process_count) as p:

--- a/pytest_splunk_addon/standard_lib/sample_generation/sample_generator.py
+++ b/pytest_splunk_addon/standard_lib/sample_generation/sample_generator.py
@@ -3,16 +3,17 @@ from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 
 from . import EventgenParser
 from . import SampleStanza
+from itertools import cycle
 
 class SampleGenerator(object):
     """
     Main Class
     Generate sample objects 
     """
-    sample_stanzas = []
+    sample_stanzas = {}
     splunk_test_type = " "
     
-    def __init__(self, addon_path, process_count=4):
+    def __init__(self, addon_path, config_path=None, bulk_event_ingestion=True, process_count=4):
         """
         init method for the class
         
@@ -22,20 +23,25 @@ class SampleGenerator(object):
         """
         self.addon_path = addon_path
         self.process_count = process_count
+        self.config_path = config_path
+        self.bulk_event_ingestion = bulk_event_ingestion
 
     def get_samples(self):
         """
         Generate SampleEvent object
         """
-        if not SampleGenerator.sample_stanzas:
-            eventgen_parser = EventgenParser(self.addon_path)
-            SampleGenerator.sample_stanzas = list(eventgen_parser.get_sample_stanzas())
+        if not SampleGenerator.sample_stanzas.get(self.bulk_event_ingestion):
+            eventgen_parser = EventgenParser(self.addon_path, config_path=self.config_path)
+            sample_stanzas = list(
+                eventgen_parser.get_sample_stanzas()
+            )
             self.splunk_test_type = eventgen_parser.splunk_test_type
-            with ThreadPoolExecutor(min(20, len(SampleGenerator.sample_stanzas))) as t:
-                t.map(SampleStanza.get_raw_events, SampleGenerator.sample_stanzas)
+            with ThreadPoolExecutor(min(20, len(sample_stanzas))) as t:
+                t.map(SampleStanza.get_raw_events, sample_stanzas)
             # with ProcessPoolExecutor(self.process_count) as p:
-            _ = list(map(SampleStanza.tokenize, SampleGenerator.sample_stanzas))
-        for each_sample in SampleGenerator.sample_stanzas:
+            _ = list(map(SampleStanza.tokenize, sample_stanzas, cycle([self.bulk_event_ingestion])))
+            SampleGenerator.sample_stanzas[self.bulk_event_ingestion] = sample_stanzas
+        for each_sample in SampleGenerator.sample_stanzas[self.bulk_event_ingestion]:
             each_sample = map(add_time, each_sample.get_tokenized_events())
             yield from each_sample
 

--- a/pytest_splunk_addon/standard_lib/sample_generation/sample_stanza.py
+++ b/pytest_splunk_addon/standard_lib/sample_generation/sample_stanza.py
@@ -28,7 +28,6 @@ class SampleStanza(object):
         self.sample_path = sample_path
         self.sample_name = os.path.basename(sample_path)
         self.sample_rules = list(self._parse_rules(eventgen_params, self.sample_path))
-        # self.input_type = eventgen_params.get('input_type')
         self.metadata = self._parse_meta(eventgen_params)
         self.input_type = self.metadata.get("input_type", "default")
         self.host_count = 0
@@ -50,21 +49,28 @@ class SampleStanza(object):
             )
             yield event
 
-    def tokenize(self):
+    def tokenize(self, bulk_event_ingestion):
         """
         Tokenize the raw events(self.sample_raw_data) and stores them into self.tokenized_events.
         For backward compatibility added required count support.
         """
-        required_event_count =self.metadata.get("count", 1)
         event = list(self.tokenized_events)
-        for each_rule in self.sample_rules:
-            if each_rule:
-                event = each_rule.apply(event)
-        while event and (int(required_event_count)) > len((event)):
+
+        if bulk_event_ingestion :
+            required_event_count = self.metadata.get("count")
+            if required_event_count == '0' or required_event_count is None:
+                required_event_count = 100
             for each_rule in self.sample_rules:
-                if each_rule:
+                event = each_rule.apply(event)
+            while event and (int(required_event_count)) > len((event)):
+                for each_rule in self.sample_rules:
                     event = each_rule.apply(event)    
-            event.extend(event)
+                event.extend(event)
+                event = event[:int(required_event_count)]
+
+        else:    
+            for each_rule in self.sample_rules:
+                event = each_rule.apply(event)        
         self.tokenized_events = event
 
     def _parse_rules(self, eventgen_params, sample_path):

--- a/pytest_splunk_addon/standard_lib/sample_generation/sample_stanza.py
+++ b/pytest_splunk_addon/standard_lib/sample_generation/sample_stanza.py
@@ -4,7 +4,7 @@ import copy
 from . import Rule
 from . import SampleEvent
 
-
+BULK_EVENT_COUNT = 100
 class SampleStanza(object):
     """
     This class represents a stanza of the eventgen.conf.
@@ -59,14 +59,14 @@ class SampleStanza(object):
         if bulk_event_ingestion :
             required_event_count = self.metadata.get("count")
             if required_event_count == '0' or required_event_count is None:
-                required_event_count = 100
+                required_event_count = BULK_EVENT_COUNT
             for each_rule in self.sample_rules:
                 event = each_rule.apply(event)
             while event and (int(required_event_count)) > len((event)):
                 for each_rule in self.sample_rules:
                     event = each_rule.apply(event)    
                 event.extend(event)
-                event = event[:int(required_event_count)]
+            event = event[:int(required_event_count)]
 
         else:    
             for each_rule in self.sample_rules:

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ setup(
         "splunk_appinspect>=2.0.1",
         "six",
         "jsonschema~=3.2.0",
-        "faker"
+        "faker",
+        "pytest-ordering~=0.6"
     ],
     extras_require={"docker": ["lovely-pytest-docker>=0.1.0"]},
     setup_requires=["pytest-runner"],


### PR DESCRIPTION
As part of this PR, following support has been added:

- Backward Compatibility with eventgen.conf i.e search-time tests(knowledge objects/cim tests) run as expected.

- First Indextime tests should run followed by search-time tests.

- Added support of param for providing a configurable path for pytest-splunk-addon-sample-generator.conf.