### PR TITLE
Feature/ACD: 4496 data ingestion irrespective of test type

### DIFF
--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -482,41 +482,7 @@ def splunk_ingest_data(request, splunk_hec_uri, sc4s):
         "splunk_host": sc4s[0],  # for sc4s
         "sc4s_port": sc4s[1][514],  # for sc4s
     }
-    IngestorHelper.ingest_events(
-        ingest_meta_data, addon_path, config_path, bulk_event_ingestion=False
-    )
-
-
-@pytest.fixture(scope="class")
-def splunk_ingest_bulk_data(request, splunk_hec_uri, sc4s):
-    """
-    Generates events in bulk for the add-on and ingests into Splunk.
-    The ingestion can be done using the following methods:
-        1. HEC Event
-        2. HEC Raw
-        3. SC4S:TCP or SC4S:UDP
-        4. HEC Metrics
-
-    Args:
-    splunk_hec_uri(tuple): Details for hec uri and session headers
-    sc4s(tuple): Details for sc4s server and TCP port
-
-    TODO: For splunk_type=external, data will not be ingested as 
-    manual configurations are required.
-    """
-    addon_path = request.config.getoption("splunk_app")
-    config_path = request.config.getoption("splunk_data_generator")
-
-    ingest_meta_data = {
-        "session_headers": splunk_hec_uri[0].headers,
-        "splunk_hec_uri": splunk_hec_uri[1],
-        "splunk_host": sc4s[0],  # for sc4s
-        "sc4s_port": sc4s[1][514],  # for sc4s
-    }
-
-    IngestorHelper.ingest_events(
-        ingest_meta_data, addon_path, config_path, bulk_event_ingestion=True
-    )
+    IngestorHelper.ingest_events(ingest_meta_data, addon_path, config_path)
 
 
 def is_responsive_splunk(splunk):

--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -156,24 +156,22 @@ def pytest_addoption(parser):
         action="store",
         dest="splunk_data_generator",
         default="pytest-splunk-addon-data-generator.conf",
-        help=(
-            "Path to pytest-splunk-addon-data-generator.conf."
-        ),
-    ) 
+        help=("Path to pytest-splunk-addon-data-generator.conf."),
+    )
     group.addoption(
         "--sc4s-host",
         action="store",
         dest="sc4s_host",
         default="127.0.0.1",
-        help="Address of the sc4s Server"
+        help="Address of the sc4s Server",
     )
     group.addoption(
         "--sc4s-port",
         action="store",
         dest="sc4s_port",
         default="514",
-        help="SC4S Port. default is 514"
-    )    
+        help="SC4S Port. default is 514",
+    )
     group.addoption(
         "--search-index",
         action="store",
@@ -274,32 +272,22 @@ def splunk(request):
         request.fixturenames.append("splunk_external")
         splunk_info = request.getfixturevalue("splunk_external")
     elif splunk_type == "docker":
-        os.environ["SPLUNK_APP_PACKAGE"] = request.config.getoption(
-            "splunk_app"
-        )
+        os.environ["SPLUNK_APP_PACKAGE"] = request.config.getoption("splunk_app")
         try:
             config = configparser.ConfigParser()
             config.read(
                 os.path.join(
-                    request.config.getoption("splunk_app"),
-                    "default",
-                    "app.conf",
+                    request.config.getoption("splunk_app"), "default", "app.conf",
                 )
             )
             os.environ["SPLUNK_APP_ID"] = config["package"]["id"]
         except Exception as e:
             pass
             os.environ["SPLUNK_APP_ID"] = "TA_package"
-        os.environ["SPLUNK_HEC_TOKEN"] = request.config.getoption(
-            "splunk_hec_token"
-        )
+        os.environ["SPLUNK_HEC_TOKEN"] = request.config.getoption("splunk_hec_token")
         os.environ["SPLUNK_USER"] = request.config.getoption("splunk_user")
-        os.environ["SPLUNK_PASSWORD"] = request.config.getoption(
-            "splunk_password"
-        )
-        os.environ["SPLUNK_VERSION"] = request.config.getoption(
-            "splunk_version"
-        )
+        os.environ["SPLUNK_PASSWORD"] = request.config.getoption("splunk_password")
+        os.environ["SPLUNK_VERSION"] = request.config.getoption("splunk_version")
 
         request.fixturenames.append("splunk_docker")
         splunk_info = request.getfixturevalue("splunk_docker")
@@ -364,9 +352,7 @@ def splunk_docker(request, docker_services, docker_compose_files):
     )
 
     docker_services.wait_until_responsive(
-        timeout=180.0,
-        pause=0.5,
-        check=lambda: is_responsive_splunk(splunk_info),
+        timeout=180.0, pause=0.5, check=lambda: is_responsive_splunk(splunk_info),
     )
 
     return splunk_info
@@ -394,7 +380,8 @@ def splunk_external(request):
         if is_responsive_splunk(splunk_info):
             break
         sleep(1)
-    else:
+
+    if not is_responsive_splunk(splunk_info):
         raise Exception(
             "Could not connect to the external Splunk. "
             "Please check the log file for possible errors."
@@ -416,6 +403,7 @@ def sc4s_docker(docker_services):
 
     return docker_services.docker_ip, ports
 
+
 @pytest.fixture(scope="session")
 def sc4s_external(request):
     """
@@ -423,11 +411,11 @@ def sc4s_external(request):
     TODO: For splunk_type=external, data will not be ingested as 
     manual configurations are required.
     """
-    ports = {514: int(request.config.getoption('sc4s_port'))}
+    ports = {514: int(request.config.getoption("sc4s_port"))}
     for x in range(5000, 5050):
         ports.update({x: x})
 
-    return request.config.getoption('sc4s_host'), ports
+    return request.config.getoption("sc4s_host"), ports
 
 
 @pytest.fixture(scope="session")
@@ -492,9 +480,11 @@ def splunk_ingest_data(request, splunk_hec_uri, sc4s):
         "session_headers": splunk_hec_uri[0].headers,
         "splunk_hec_uri": splunk_hec_uri[1],
         "splunk_host": sc4s[0],  # for sc4s
-        "sc4s_port": sc4s[1][514]  # for sc4s
+        "sc4s_port": sc4s[1][514],  # for sc4s
     }
-    IngestorHelper.ingest_events(ingest_meta_data, addon_path, config_path, bulk_event_ingestion=False)
+    IngestorHelper.ingest_events(
+        ingest_meta_data, addon_path, config_path, bulk_event_ingestion=False
+    )
 
 
 @pytest.fixture(scope="class")
@@ -521,10 +511,13 @@ def splunk_ingest_bulk_data(request, splunk_hec_uri, sc4s):
         "session_headers": splunk_hec_uri[0].headers,
         "splunk_hec_uri": splunk_hec_uri[1],
         "splunk_host": sc4s[0],  # for sc4s
-        "sc4s_port": sc4s[1][514]  # for sc4s
+        "sc4s_port": sc4s[1][514],  # for sc4s
     }
 
-    IngestorHelper.ingest_events(ingest_meta_data, addon_path, config_path, bulk_event_ingestion=True)
+    IngestorHelper.ingest_events(
+        ingest_meta_data, addon_path, config_path, bulk_event_ingestion=True
+    )
+
 
 def is_responsive_splunk(splunk):
     """
@@ -538,8 +531,7 @@ def is_responsive_splunk(splunk):
     """
     try:
         LOGGER.info(
-            "Trying to connect Splunk instance...  splunk=%s",
-            json.dumps(splunk),
+            "Trying to connect Splunk instance...  splunk=%s", json.dumps(splunk),
         )
         client.connect(
             username=splunk["username"],
@@ -551,8 +543,7 @@ def is_responsive_splunk(splunk):
         return True
     except Exception as e:
         LOGGER.warning(
-            "Could not connect to Splunk yet. Will try again. exception=%s",
-            str(e),
+            "Could not connect to Splunk yet. Will try again. exception=%s", str(e),
         )
         return False
 
@@ -576,9 +567,7 @@ def is_responsive(url):
             return True
     except ConnectionError as e:
         LOGGER.warning(
-            "Could not connect to url yet. Will try again. exception=%s",
-            str(e),
+            "Could not connect to url yet. Will try again. exception=%s", str(e),
         )
         return False
-
 

--- a/pytest_splunk_addon/standard_lib/cim_tests/test_templates.py
+++ b/pytest_splunk_addon/standard_lib/cim_tests/test_templates.py
@@ -54,7 +54,7 @@ class CIMTestTemplates(object):
     @pytest.mark.splunk_searchtime_cim
     @pytest.mark.splunk_searchtime_cim_fields
     def test_cim_required_fields(
-        self, splunk_search_util, splunk_ingest_bulk_data, splunk_searchtime_cim_fields, record_property
+        self, splunk_search_util, splunk_ingest_data, splunk_searchtime_cim_fields, record_property
     ):
         """
         Test the the required fields in the data models are extracted with valid values.
@@ -156,7 +156,7 @@ class CIMTestTemplates(object):
     def test_cim_fields_not_allowed_in_search(
         self,
         splunk_search_util,
-        splunk_ingest_bulk_data,
+        splunk_ingest_data,
         splunk_searchtime_cim_fields_not_allowed_in_search,
         record_property,
     ):
@@ -239,7 +239,7 @@ class CIMTestTemplates(object):
     @pytest.mark.splunk_searchtime_cim
     @pytest.mark.splunk_searchtime_cim_fields_not_allowed_in_props
     def test_cim_fields_not_allowed_in_props(
-        self, splunk_ingest_bulk_data, splunk_searchtime_cim_fields_not_allowed_in_props, record_property
+        self, splunk_ingest_data, splunk_searchtime_cim_fields_not_allowed_in_props, record_property
     ):
         result_str = (
             "The field extractions are not allowed in the configuration files"
@@ -265,7 +265,7 @@ class CIMTestTemplates(object):
     def test_eventtype_mapped_multiple_cim_datamodel(
         self,
         splunk_search_util,
-        splunk_ingest_bulk_data,
+        splunk_ingest_data,
         splunk_searchtime_cim_mapped_datamodel,
         record_property,
         caplog,

--- a/pytest_splunk_addon/standard_lib/event_ingestors/ingestor_helper.py
+++ b/pytest_splunk_addon/standard_lib/event_ingestors/ingestor_helper.py
@@ -30,7 +30,7 @@ class IngestorHelper(object):
         return ingestor
 
     @classmethod
-    def ingest_events(cls, ingest_meta_data, addon_path, config_path, bulk_event_ingestion):
+    def ingest_events(cls, ingest_meta_data, addon_path, config_path):
         """
         Events are ingested in the splunk.
         Args:
@@ -40,7 +40,7 @@ class IngestorHelper(object):
             bulk_event_ingestion(bool): Boolean param for bulk event ingestion.
 
         """
-        sample_generator = SampleGenerator(addon_path, config_path, bulk_event_ingestion=bulk_event_ingestion)
+        sample_generator = SampleGenerator(addon_path, config_path)
         ingestor_dict = dict()
         for event in sample_generator.get_samples():
             input_type = event.metadata.get("input_type")

--- a/pytest_splunk_addon/standard_lib/fields_tests/test_templates.py
+++ b/pytest_splunk_addon/standard_lib/fields_tests/test_templates.py
@@ -41,7 +41,7 @@ class FieldTestTemplates(object):
     @pytest.mark.splunk_searchtime_fields
     @pytest.mark.splunk_searchtime_fields_positive
     def test_props_fields(
-        self, splunk_search_util, splunk_ingest_bulk_data, splunk_searchtime_fields_positive, record_property
+        self, splunk_search_util, splunk_ingest_data, splunk_searchtime_fields_positive, record_property
     ):
         """
         This test case checks that a field value has the expected values.
@@ -91,7 +91,7 @@ class FieldTestTemplates(object):
     @pytest.mark.splunk_searchtime_fields
     @pytest.mark.splunk_searchtime_fields_negative
     def test_props_fields_no_dash_not_empty(
-        self, splunk_search_util, splunk_ingest_bulk_data, splunk_searchtime_fields_negative, record_property
+        self, splunk_search_util, splunk_ingest_data, splunk_searchtime_fields_negative, record_property
     ):
         """
         This test case checks negative scenario for the field value.
@@ -145,7 +145,7 @@ class FieldTestTemplates(object):
     @pytest.mark.splunk_searchtime_fields
     @pytest.mark.splunk_searchtime_fields_tags
     def test_tags(
-        self, splunk_search_util, splunk_ingest_bulk_data, splunk_searchtime_fields_tags, record_property, caplog
+        self, splunk_search_util, splunk_ingest_data, splunk_searchtime_fields_tags, record_property, caplog
     ):
         """
         Test case to check tags mentioned in tags.conf
@@ -200,7 +200,7 @@ class FieldTestTemplates(object):
     def test_eventtype(
         self,
         splunk_search_util,
-        splunk_ingest_bulk_data,
+        splunk_ingest_data,
         splunk_searchtime_fields_eventtypes,
         record_property,
         caplog,

--- a/pytest_splunk_addon/standard_lib/index_tests/test_generator.py
+++ b/pytest_splunk_addon/standard_lib/index_tests/test_generator.py
@@ -9,10 +9,10 @@ LOGGER = logging.getLogger("pytest-splunk-addon")
 class IndexTimeTestGenerator(object):
     def generate_tests(self, app_path, config_path, test_type):
         sample_generator = SampleGenerator(
-            app_path, config_path, bulk_event_ingestion=False)
+            app_path, config_path)
         tokenized_events = list(sample_generator.get_samples())
 
-        if not SampleGenerator.splunk_test_type == "splunk_indextime":
+        if not SampleGenerator.conf_name == "psa-data-gen":
             return " Index Time tests cannot be executed using eventgen.conf,\
                  pytest-splunk-addon-data-generator.conf is required."
 

--- a/pytest_splunk_addon/standard_lib/sample_generation/eventgen_parser.py
+++ b/pytest_splunk_addon/standard_lib/sample_generation/eventgen_parser.py
@@ -17,25 +17,46 @@ class EventgenParser:
     Args:
         addon_path (str): Path to the Splunk App 
     """
+
     splunk_test_type = " "
 
     def __init__(self, addon_path, config_path=None):
         self._app = App(addon_path, python_analyzer_enable=False)
-        self.config_path = config_path 
+        self.config_path = config_path
         self._eventgen = None
         self.addon_path = addon_path
-        self.path_to_samples = os.path.join(addon_path, "samples")
         self.match_stanzas = set()
+
+    @property
+    def path_to_samples(self):
+        if os.path.exists(os.path.join(self.config_path, "samples")):
+            return os.path.join(self.config_path, "samples")
+        elif os.path.exists(
+            os.path.join(
+                os.path.abspath(os.path.join(self.config_path, os.pardir)), "samples"
+            )
+        ):
+            return os.path.join(
+                os.path.abspath(os.path.join(self.config_path, os.pardir)), "samples"
+            )
+        else:
+            return os.path.join(self.addon_path, "samples")
 
     @property
     def eventgen(self):
         try:
             relative_path = os.path.relpath(self.config_path, self.addon_path)
-            if os.path.exists(os.path.join(self.config_path, "pytest-splunk-addon-data-generator.conf")):
-                self._eventgen = self._app.get_config("pytest-splunk-addon-data-generator.conf", dir=relative_path)
+            if os.path.exists(
+                os.path.join(
+                    self.config_path, "pytest-splunk-addon-data-generator.conf"
+                )
+            ):
+                self._eventgen = self._app.get_config(
+                    "pytest-splunk-addon-data-generator.conf", dir=relative_path
+                )
                 self.splunk_test_type = "splunk_indextime"
             else:
-                self._eventgen = self._app.get_config("eventgen.conf")    
+                self._eventgen = self._app.get_config("eventgen.conf")
                 self.splunk_test_type = "splunk_searchtime"
             return self._eventgen
         except OSError:
@@ -54,8 +75,7 @@ class EventgenParser:
         for sample_name, stanza_params in eventgen_dict.items():
             sample_path = os.path.join(self.path_to_samples, sample_name)
             yield SampleStanza(
-                sample_path,
-                stanza_params,
+                sample_path, stanza_params,
             )
 
     def get_eventgen_stanzas(self):
@@ -84,26 +104,33 @@ class EventgenParser:
             Dictionary representing eventgen.conf in the above format.
         """
         eventgen_dict = {}
-        child_dict = {'tokens': {}}
+        child_dict = {"tokens": {}}
         if os.path.exists(self.path_to_samples):
             for sample_file in os.listdir(self.path_to_samples):
                 for stanza in self.eventgen.sects:
                     if re.search(stanza, sample_file):
                         self.match_stanzas.add(stanza)
                         eventgen_sections = self.eventgen.sects[stanza]
-                        eventgen_dict.setdefault((sample_file), {
-                            'tokens': {}
-                        })
+                        eventgen_dict.setdefault((sample_file), {"tokens": {}})
                         for stanza_param in eventgen_sections.options:
                             eventgen_property = eventgen_sections.options[stanza_param]
-                            if eventgen_property.name.startswith('token'):
-                                _, token_id, token_param = eventgen_property.name.split('.')
+                            if eventgen_property.name.startswith("token"):
+                                _, token_id, token_param = eventgen_property.name.split(
+                                    "."
+                                )
                                 token_key = "{}_{}".format(stanza, token_id)
-                                if not token_key in eventgen_dict[sample_file]['tokens'].keys():
-                                    eventgen_dict[sample_file]['tokens'][token_key] = {}
-                                eventgen_dict[sample_file]['tokens'][token_key][token_param] = eventgen_property.value
+                                if (
+                                    not token_key
+                                    in eventgen_dict[sample_file]["tokens"].keys()
+                                ):
+                                    eventgen_dict[sample_file]["tokens"][token_key] = {}
+                                eventgen_dict[sample_file]["tokens"][token_key][
+                                    token_param
+                                ] = eventgen_property.value
                             else:
-                                eventgen_dict[sample_file][eventgen_property.name] = eventgen_property.value
+                                eventgen_dict[sample_file][
+                                    eventgen_property.name
+                                ] = eventgen_property.value
         return eventgen_dict
 
     def check_samples(self):
@@ -113,5 +140,11 @@ class EventgenParser:
         if os.path.exists(self.path_to_samples):
             for stanza in self.eventgen.sects:
                 if stanza not in self.match_stanzas:
-                    LOGGER.warning("No sample file found for stanza : {}".format(stanza))
-                    warnings.warn(UserWarning("No sample file found for stanza : {}".format(stanza)))
+                    LOGGER.warning(
+                        "No sample file found for stanza : {}".format(stanza)
+                    )
+                    warnings.warn(
+                        UserWarning(
+                            "No sample file found for stanza : {}".format(stanza)
+                        )
+                    )

--- a/pytest_splunk_addon/standard_lib/sample_generation/eventgen_parser.py
+++ b/pytest_splunk_addon/standard_lib/sample_generation/eventgen_parser.py
@@ -18,7 +18,7 @@ class EventgenParser:
         addon_path (str): Path to the Splunk App 
     """
 
-    splunk_test_type = " "
+    conf_name = " "
 
     def __init__(self, addon_path, config_path=None):
         self._app = App(addon_path, python_analyzer_enable=False)
@@ -54,10 +54,10 @@ class EventgenParser:
                 self._eventgen = self._app.get_config(
                     "pytest-splunk-addon-data-generator.conf", dir=relative_path
                 )
-                self.splunk_test_type = "splunk_indextime"
+                self.conf_name = "psa-data-gen"
             else:
                 self._eventgen = self._app.get_config("eventgen.conf")
-                self.splunk_test_type = "splunk_searchtime"
+                self.conf_name = "eventgen"
             return self._eventgen
         except OSError:
             LOGGER.warning("eventgen.conf not found.")

--- a/pytest_splunk_addon/standard_lib/sample_generation/sample_generator.py
+++ b/pytest_splunk_addon/standard_lib/sample_generation/sample_generator.py
@@ -10,10 +10,10 @@ class SampleGenerator(object):
     Main Class
     Generate sample objects 
     """
-    sample_stanzas = {}
-    splunk_test_type = " "
+    sample_stanzas = []
+    conf_name = " "
     
-    def __init__(self, addon_path, config_path=None, bulk_event_ingestion=True, process_count=4):
+    def __init__(self, addon_path, config_path=None,process_count=4):
         """
         init method for the class
         
@@ -24,24 +24,23 @@ class SampleGenerator(object):
         self.addon_path = addon_path
         self.process_count = process_count
         self.config_path = config_path
-        self.bulk_event_ingestion = bulk_event_ingestion
 
     def get_samples(self):
         """
         Generate SampleEvent object
         """
-        if not SampleGenerator.sample_stanzas.get(self.bulk_event_ingestion):
+        if not SampleGenerator.sample_stanzas:
             eventgen_parser = EventgenParser(self.addon_path, config_path=self.config_path)
             sample_stanzas = list(
                 eventgen_parser.get_sample_stanzas()
             )
-            SampleGenerator.splunk_test_type = eventgen_parser.splunk_test_type
+            SampleGenerator.conf_name = eventgen_parser.conf_name
             with ThreadPoolExecutor(min(20, max(len(sample_stanzas), 1))) as t:
                 t.map(SampleStanza.get_raw_events, sample_stanzas)
             # with ProcessPoolExecutor(self.process_count) as p:
-            _ = list(map(SampleStanza.tokenize, sample_stanzas, cycle([self.bulk_event_ingestion])))
-            SampleGenerator.sample_stanzas[self.bulk_event_ingestion] = sample_stanzas
-        for each_sample in SampleGenerator.sample_stanzas[self.bulk_event_ingestion]:
+            _ = list(map(SampleStanza.tokenize, sample_stanzas, cycle([SampleGenerator.conf_name])))
+            SampleGenerator.sample_stanzas = sample_stanzas
+        for each_sample in SampleGenerator.sample_stanzas:
             each_sample = map(add_time, each_sample.get_tokenized_events())
             yield from each_sample
 


### PR DESCRIPTION
As a part of this PR, following has been implemented:

Data ingestion is now done based on the conf file, i.e

- For the new conf file **'pytest-splunk-addon-data-generator.conf'** the number of events which will be ingested will depend on the no. of lines in sample file and the occurrence of  **'replacementType'= all**  in the conf file.

- **For eventgen.conf**, the number of events which will be ingested will depend on the count parameter. i.e 
For count = 0 or count > 250 or count parameter is not present in the conf, 250 events will be generated.
For count > 0 and count < 250 **'count'** no. of events will be ingested.

