### PR TITLE
Base 10958 fixing issues

### DIFF
--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -489,7 +489,7 @@ def splunk_ingest_data(request, splunk_hec_uri, sc4s):
     splunk_hec_uri(tuple): Details for hec uri and session headers
     sc4s(tuple): Details for sc4s server and TCP port
 
-    TODO: For splunk_type=external, data will not be ingested as 
+    TODO: For splunk_type=external, data will not be ingested as
     manual configurations are required.
     """
     global PYTEST_XDIST_TESTRUNUID
@@ -504,6 +504,7 @@ def splunk_ingest_data(request, splunk_hec_uri, sc4s):
             "sc4s_port": sc4s[1][514]  # for sc4s
         }
         IngestorHelper.ingest_events(ingest_meta_data, addon_path, config_path)
+        sleep(50)
         if ("PYTEST_XDIST_WORKER" in os.environ):
             with open(os.environ.get("PYTEST_XDIST_TESTRUNUID") + "_wait", "w+"):
                 PYTEST_XDIST_TESTRUNUID = os.environ.get("PYTEST_XDIST_TESTRUNUID")

--- a/pytest_splunk_addon/standard_lib/sample_generation/eventgen_parser.py
+++ b/pytest_splunk_addon/standard_lib/sample_generation/eventgen_parser.py
@@ -47,7 +47,8 @@ class EventgenParser:
             relative_path = os.path.relpath(self.config_path, self.addon_path)
             if os.path.exists(
                 os.path.join(
-                    self.config_path, "pytest-splunk-addon-data.conf"
+                    self.config_path,
+                    "pytest-splunk-addon-data.conf"
                 )
             ):
                 self._eventgen = self._app.get_config(

--- a/pytest_splunk_addon/standard_lib/sample_generation/eventgen_parser.py
+++ b/pytest_splunk_addon/standard_lib/sample_generation/eventgen_parser.py
@@ -59,8 +59,8 @@ class EventgenParser:
                 self.conf_name = "eventgen"
             return self._eventgen
         except OSError:
-            LOGGER.warning("eventgen.conf not found.")
-            return None
+            LOGGER.warning("pytest-splunk-addon-data.conf/eventgen.conf not Found")
+            raise FileNotFoundError("pytest-splunk-addon-data.conf/eventgen.conf not Found")
 
     def get_sample_stanzas(self):
         """

--- a/pytest_splunk_addon/standard_lib/sample_generation/rule.py
+++ b/pytest_splunk_addon/standard_lib/sample_generation/rule.py
@@ -591,11 +591,11 @@ class TimeRule(Rule):
                 )
 
             if r"%s" == self.replacement.strip("'").strip('"'):
-                yield self.token_value(
-                    *([self.replacement.replace(
-                        r"%s", str(int(mktime(random_time.timetuple())))
-                        )]*2)
+                t = self.replacement.replace(
+                    r"%s",
+                    str(int(mktime(random_time.timetuple())))
                     )
+                yield self.token_value(float(t), t)
 
             else:
                 if timezone_time not in (None, '0000'):

--- a/pytest_splunk_addon/standard_lib/sample_generation/rule.py
+++ b/pytest_splunk_addon/standard_lib/sample_generation/rule.py
@@ -591,11 +591,11 @@ class TimeRule(Rule):
                 )
 
             if r"%s" == self.replacement.strip("'").strip('"'):
-                t = self.replacement.replace(
+                time_in_sec = self.replacement.replace(
                     r"%s",
                     str(int(mktime(random_time.timetuple())))
                     )
-                yield self.token_value(float(t), t)
+                yield self.token_value(float(time_in_sec), time_in_sec)
 
             else:
                 if timezone_time not in (None, '0000'):


### PR DESCRIPTION
- Raised appropriate exception when eventgen.conf and pytest-splunk-addon-data.conf are not found.

- Added 50 second sleep after ingestion for the data to become searchable.

- Handle named_tuple generation for TimeRule when replacement is %S.