### PR TITLE
BASE-10958:Reverted-setup_failures

### DIFF
--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -204,7 +204,7 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture(scope="session")
-def splunk_setup(splunk_ingest_data, splunk):
+def splunk_setup(splunk):
     """
     Override this fixture in conftest.py, if any setup is required before the test session.
     splunk fixture can provide the details of the splunk instance in dict format.

--- a/pytest_splunk_addon/standard_lib/cim_tests/test_templates.py
+++ b/pytest_splunk_addon/standard_lib/cim_tests/test_templates.py
@@ -24,7 +24,7 @@ class CIMTestTemplates(object):
     @pytest.mark.splunk_searchtime_cim
     @pytest.mark.splunk_searchtime_cim_fields
     def test_cim_required_fields(
-        self, splunk_search_util, splunk_searchtime_cim_fields, record_property
+        self, splunk_search_util, splunk_ingest_data, splunk_searchtime_cim_fields, record_property
     ):
         """
         Test the the required fields in the data models are extracted with valid values.
@@ -131,6 +131,7 @@ class CIMTestTemplates(object):
     @pytest.mark.splunk_searchtime_cim_fields_not_allowed_in_search
     def test_cim_fields_not_allowed_in_search(
         self,
+        splunk_ingest_data,
         splunk_search_util,
         splunk_searchtime_cim_fields_not_allowed_in_search,
         record_property,
@@ -223,7 +224,7 @@ class CIMTestTemplates(object):
     @pytest.mark.splunk_searchtime_cim
     @pytest.mark.splunk_searchtime_cim_fields_not_allowed_in_props
     def test_cim_fields_not_allowed_in_props(
-        self, splunk_searchtime_cim_fields_not_allowed_in_props, record_property
+        self, splunk_ingest_data, splunk_searchtime_cim_fields_not_allowed_in_props, record_property
     ):
         """
         This testcase checks for cim field of type ["not_allowed_in_search_and_props", "not_allowed_in_props"] if an extraction is defined in the configuration file.
@@ -252,6 +253,7 @@ class CIMTestTemplates(object):
     def test_eventtype_mapped_multiple_cim_datamodel(
         self,
         splunk_search_util,
+        splunk_ingest_data,
         splunk_searchtime_cim_mapped_datamodel,
         record_property,
         caplog,

--- a/pytest_splunk_addon/standard_lib/fields_tests/test_templates.py
+++ b/pytest_splunk_addon/standard_lib/fields_tests/test_templates.py
@@ -40,7 +40,7 @@ class FieldTestTemplates(object):
     @pytest.mark.splunk_searchtime_fields
     @pytest.mark.splunk_searchtime_fields_positive
     def test_props_fields(
-        self, splunk_search_util, splunk_searchtime_fields_positive, record_property
+        self, splunk_search_util, splunk_ingest_data, splunk_searchtime_fields_positive, record_property
     ):
         """
         This test case checks that a field value has the expected values.
@@ -90,7 +90,7 @@ class FieldTestTemplates(object):
     @pytest.mark.splunk_searchtime_fields
     @pytest.mark.splunk_searchtime_fields_negative
     def test_props_fields_no_dash_not_empty(
-        self, splunk_search_util, splunk_searchtime_fields_negative, record_property
+        self, splunk_search_util, splunk_ingest_data, splunk_searchtime_fields_negative, record_property
     ):
         """
         This test case checks negative scenario for the field value.
@@ -144,7 +144,7 @@ class FieldTestTemplates(object):
     @pytest.mark.splunk_searchtime_fields
     @pytest.mark.splunk_searchtime_fields_tags
     def test_tags(
-        self, splunk_search_util, splunk_searchtime_fields_tags, record_property, caplog
+        self, splunk_search_util, splunk_ingest_data, splunk_searchtime_fields_tags, record_property, caplog
     ):
         """
         Test case to check tags mentioned in tags.conf
@@ -199,6 +199,7 @@ class FieldTestTemplates(object):
     def test_eventtype(
         self,
         splunk_search_util,
+        splunk_ingest_data,
         splunk_searchtime_fields_eventtypes,
         record_property,
         caplog,

--- a/pytest_splunk_addon/standard_lib/index_tests/test_templates.py
+++ b/pytest_splunk_addon/standard_lib/index_tests/test_templates.py
@@ -18,6 +18,7 @@ class IndexTimeTestTemplate(object):
     def test_indextime_key_fields(
         self,
         splunk_search_util,
+        splunk_ingest_data,
         splunk_indextime_key_fields,
         record_property,
         caplog,
@@ -125,6 +126,7 @@ class IndexTimeTestTemplate(object):
     def test_indextime_time(
         self,
         splunk_search_util,
+        splunk_ingest_data,
         splunk_indextime_time,
         record_property,
         caplog,
@@ -198,6 +200,7 @@ class IndexTimeTestTemplate(object):
     def test_indextime_line_breaker(
         self,
         splunk_search_util,
+        splunk_ingest_data,
         splunk_indextime_line_breaker,
         record_property,
         caplog,


### PR DESCRIPTION
- Added ingestion fixtures to the test_templates to avoid setup_fixtures failures.