### PR TITLE
BASE-7106:Changed-variable-names-for-sc4s-external

### DIFF
--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -500,7 +500,7 @@ def splunk_ingest_data(request, splunk_hec_uri, sc4s):
         ingest_meta_data = {
             "session_headers": splunk_hec_uri[0].headers,
             "splunk_hec_uri": splunk_hec_uri[1],
-            "splunk_host": sc4s[0],  # for sc4s
+            "sc4s_host": sc4s[0],  # for sc4s
             "sc4s_port": sc4s[1][514]  # for sc4s
         }
         IngestorHelper.ingest_events(ingest_meta_data, addon_path, config_path)

--- a/pytest_splunk_addon/standard_lib/event_ingestors/sc4s_event_ingestor.py
+++ b/pytest_splunk_addon/standard_lib/event_ingestors/sc4s_event_ingestor.py
@@ -15,7 +15,7 @@ class SC4SEventIngestor(EventIngestor):
     The format for required_configs is::
 
         {
-            splunk_host (str): Address of the Splunk Server. Do not provide http scheme in the host.
+            sc4s_host (str): Address of the Splunk Server. Do not provide http scheme in the host.
             sc4s_port (int): Port number of the above host address
         }
 
@@ -24,9 +24,9 @@ class SC4SEventIngestor(EventIngestor):
     """
 
     def __init__(self, required_configs):
-        self.splunk_host = required_configs['splunk_host']
+        self.sc4s_host = required_configs['sc4s_host']
         self.sc4s_port = required_configs['sc4s_port']
-        self.server_address = (required_configs['splunk_host'], required_configs['sc4s_port'])
+        self.server_address = (required_configs['sc4s_host'], required_configs['sc4s_port'])
 
     def ingest(self, events):
         """


### PR DESCRIPTION
This PR contains:

- Updation of variable name for sc4s_host so as to be compatible with sc4s docker and external. 