### PR TITLE
BASE-11034: Resolution for the bug: 'KeyError: tokens' generated by the utility

### DIFF
--- a/pytest_splunk_addon/standard_lib/utilities/create_new_eventgen.py
+++ b/pytest_splunk_addon/standard_lib/utilities/create_new_eventgen.py
@@ -83,6 +83,7 @@ class UpdateEventgen():
                         eventgen_dict.setdefault((sample_file), {})
                         eventgen_dict[sample_file]["sample_count"] = events_in_file
                         eventgen_dict[sample_file]["add_comment"] = True
+                        eventgen_dict[sample_file]["tokens"] = {}
 
         return eventgen_dict
 
@@ -118,7 +119,7 @@ class UpdateEventgen():
                 'source', f"pytest-splunk-addon:{eventgen_dict[stanza_name]['input_type']}")
 
             for _, token_data in stanza_data.get("tokens", {}).items():
-                token_name = token_data.get("token").strip("#").lower()
+                token_name = token_data.get("token").strip("#()").lower()
                 for _, new_token_values in FIELD_MAPPING.items():
 
                     if token_name in new_token_values.get("token"):


### PR DESCRIPTION
This PR contains the fix for the bug in utility due to which it was not allowing to create the new pytest-splunk-addon-data.conf
The error is as shown below:
![Screenshot_83](https://user-images.githubusercontent.com/61701355/88189356-99ee3380-cc56-11ea-958c-9bb3a3dab141.png)
