### PR TITLE
BASE-11061: Updated condition to avoid postfix stanza matching.

### DIFF
--- a/pytest_splunk_addon/standard_lib/sample_generation/eventgen_parser.py
+++ b/pytest_splunk_addon/standard_lib/sample_generation/eventgen_parser.py
@@ -122,7 +122,8 @@ class EventgenParser:
         if os.path.exists(self.path_to_samples):
             for sample_file in os.listdir(self.path_to_samples):
                 for stanza in self.eventgen.sects:
-                    if re.match(stanza, sample_file):
+                    stanza_match_obj = re.search(stanza, sample_file)
+                    if stanza_match_obj and stanza_match_obj.group(0) == sample_file:
                         self.match_stanzas.add(stanza)
                         eventgen_sections = self.eventgen.sects[stanza]
                         eventgen_dict.setdefault((sample_file), {"tokens": {}})

--- a/pytest_splunk_addon/standard_lib/sample_generation/eventgen_parser.py
+++ b/pytest_splunk_addon/standard_lib/sample_generation/eventgen_parser.py
@@ -122,7 +122,7 @@ class EventgenParser:
         if os.path.exists(self.path_to_samples):
             for sample_file in os.listdir(self.path_to_samples):
                 for stanza in self.eventgen.sects:
-                    if re.search(stanza, sample_file):
+                    if re.match(stanza, sample_file):
                         self.match_stanzas.add(stanza)
                         eventgen_sections = self.eventgen.sects[stanza]
                         eventgen_dict.setdefault((sample_file), {"tokens": {}})

--- a/tests/addons/TA_fiction_indextime/default/pytest-splunk-addon-data.conf
+++ b/tests/addons/TA_fiction_indextime/default/pytest-splunk-addon-data.conf
@@ -388,10 +388,10 @@ token.13.replacement = list["<n/a>", "test"]
 # Host will be assigned via events
 # timestamp value will be assigned via plugin
 # modinput input type is used to ingest the data into splunk (will ingest one event at a time)
-# Total test cases: 7
-# 1 key_fields passed
+# Total test cases: 9
+# 2 key_fields passed
 # 4 _time passed
-# 2 line_breaker passed
+# 3 line_breaker passed
 [test_regex_.*.samples]
 sourcetype = test:indextime:sourcetype:updated_sourcetype
 host_type = plugin
@@ -435,6 +435,40 @@ token.1.field = _time
 token.2.token = ##static_value_5##
 token.2.replacementType = static
 token.2.replacement = sample_value_5
+
+# This stanza should not consider tokens and metadata of above stanza for test generation.
+[postfix_test_regex_two.samples]
+sourcetype = test:postfix:regex:stanza
+host_type = plugin
+input_type = modinput
+source = pytest-splunk-addon:modinput
+sourcetype_to_search = test:postfix:regex:stanza
+timestamp_type = plugin
+sample_count = 2
+
+token.0.token = ##static_value_1##
+token.0.replacementType = static
+token.0.replacement = sample_value_1
+
+token.1.token = ##dest##
+token.1.replacementType = random
+token.1.replacement = dest["ipv4"]
+token.1.field = dest
+
+# No testcase should generate for this stanza.
+[test_regex_]
+sourcetype = test:regex:stanza
+host_type = plugin
+input_type = modinput
+source = pytest-splunk-addon:modinput
+sourcetype_to_search = test:regex:stanza
+timestamp_type = plugin
+sample_count = 2
+
+token.0.token = ##static_value_1##
+token.0.replacementType = static
+token.0.replacement = sample_value_1
+
 
 # Test the linebreaking feature when the events are ingestd into splunk via scripted input
 # Host values will be assigned via plugin

--- a/tests/addons/TA_fiction_indextime/samples/postfix_test_regex_two.samples
+++ b/tests/addons/TA_fiction_indextime/samples/postfix_test_regex_two.samples
@@ -1,0 +1,2 @@
+postfix regex static_value_1=##static_value_1## dest=##dest##
+postfix regex static_value_1=##static_value_1## dest=##dest##

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -445,6 +445,8 @@ Define the TA_fiction_indextime add-on passed test case list.
 """
 TA_FICTION_INDEXTIME_PASSED = [
     '*test_splunk_fiction_indextime.py::Test_App::test_events_with_untokenised_values PASSED*',
+    '*test_splunk_fiction_indextime.py::Test_App::test_indextime_key_fields*test:postfix:regex:stanza::postfix_test_regex_two.samples_1_to_postfix_test_regex_two.samples_1* PASSED*',
+    '*test_splunk_fiction_indextime.py::Test_App::test_indextime_key_fields*test:postfix:regex:stanza::postfix_test_regex_two.samples_2_to_postfix_test_regex_two.samples_2* PASSED*',
     '*test_splunk_fiction_indextime.py::Test_App::test_indextime_key_fields*test:indextime:file_monitor_time_stamp_plugin::file_monitor_time_stamp_plugin.samples_to_file_monitor_time_stamp_plugin.samples* PASSED*',
     '*test_splunk_fiction_indextime.py::Test_App::test_indextime_key_fields*test:indextime:scripted_input_key_fields_fiction::scripted_input_key_fields_fiction.samples_to_scripted_input_key_fields_fiction.samples* PASSED*',
     '*test_splunk_fiction_indextime.py::Test_App::test_indextime_key_fields*test:indextime:scripted_input_line_breaking_fiction::scripted_input_line_breaking_fiction.samples_1_to_scripted_input_line_breaking_fiction.samples_1* PASSED*',
@@ -513,6 +515,7 @@ TA_FICTION_INDEXTIME_PASSED = [
     '*test_splunk_fiction_indextime.py::Test_App::test_indextime_line_breaker*test:indextime:sourcetype:user_email_relation_time_plugin::sample_file_two.samples* PASSED*',
     '*test_splunk_fiction_indextime.py::Test_App::test_indextime_line_breaker*test:indextime:sourcetype_basic::sample_file.samples* PASSED*',
     '*test_splunk_fiction_indextime.py::Test_App::test_indextime_line_breaker*test_scripted_input_sourcetype::test_scripted_input_one.samples* PASSED*',
+    '*test_splunk_fiction_indextime.py::Test_App::test_indextime_line_breaker*test:postfix:regex:stanza::postfix_test_regex_two.samples* PASSED*',
     '*test_splunk_fiction_indextime.py::Test_App::test_cim_fields_not_allowed_in_props*searchtime_cim_fields* PASSED*',
     '*test_splunk_fiction_indextime.py::Test_App::test_eventtype_mapped_multiple_cim_datamodel*mapped_datamodel_tests* PASSED*',
     '*test_splunk_fiction_indextime.py::Test_App::test_splunk_internal_errors PASSED*',


### PR DESCRIPTION
- For SNOW addon the testcases were not properly generated due to similar stanza postfix.
- i.e snow_cmdb.samples &  all_snow_cmdb.samples
- Updated the plugin code to handle such scenarios and added a stanza in TA_fiction_indextime for testing.