### PR TITLE
Encode Event: Updated list of Input type to encode the events

### DIFF
--- a/pytest_splunk_addon/helmut_lib/SearchUtil.py
+++ b/pytest_splunk_addon/helmut_lib/SearchUtil.py
@@ -1008,7 +1008,7 @@ class SearchUtil(object):
         while tryNum <= retries and not status:
             job = self.jobs.create(query, max_time=60)
             job.wait(240)
-            results = job.get_results(offset=0, count=1000)
+            results = job.get_results(offset=0, count=4000)
             result_count = len(results)
             messages = job.get_messages()
 

--- a/pytest_splunk_addon/standard_lib/event_ingestors/ingestor_helper.py
+++ b/pytest_splunk_addon/standard_lib/event_ingestors/ingestor_helper.py
@@ -46,7 +46,7 @@ class IngestorHelper(object):
         ingestor_dict = dict()
         for event in tokenized_events:
             input_type = event.metadata.get("input_type")
-            if input_type in ["modinput", "windows_input"]:
+            if input_type in ["modinput", "windows_input", "syslog_tcp", "syslog_udp"]:
                 event.event = event.event.encode("utf-8").decode()
             else:
                 event.event = event.event.encode("utf-8")

--- a/pytest_splunk_addon/standard_lib/event_ingestors/ingestor_helper.py
+++ b/pytest_splunk_addon/standard_lib/event_ingestors/ingestor_helper.py
@@ -46,7 +46,7 @@ class IngestorHelper(object):
         ingestor_dict = dict()
         for event in tokenized_events:
             input_type = event.metadata.get("input_type")
-            if not input_type=="HECRawEventIngestor":
+            if not input_type in ["file_monitor", "scripted_input", "default"]:
                 event.event = event.event.encode("utf-8").decode()
             else:
                 event.event = event.event.encode("utf-8")

--- a/pytest_splunk_addon/standard_lib/event_ingestors/ingestor_helper.py
+++ b/pytest_splunk_addon/standard_lib/event_ingestors/ingestor_helper.py
@@ -46,7 +46,7 @@ class IngestorHelper(object):
         ingestor_dict = dict()
         for event in tokenized_events:
             input_type = event.metadata.get("input_type")
-            if not input_type in ["file_monitor", "scripted_input", "default"]:
+            if input_type in ["modinput", "windows_input"]:
                 event.event = event.event.encode("utf-8").decode()
             else:
                 event.event = event.event.encode("utf-8")

--- a/tests/test_splunk_addon.py
+++ b/tests/test_splunk_addon.py
@@ -63,6 +63,8 @@ def test_splunk_connection_external(testdir):
         os.path.join(testdir.request.fspath.dirname, "addons/TA_fiction"),
         os.path.join(testdir.tmpdir, "package"),
     )
+    SampleGenerator.clean_samples()
+    Rule.clean_rules()
 
     # run pytest with the following cmd args
     result = testdir.runpytest(
@@ -96,6 +98,9 @@ def test_splunk_connection_docker(testdir):
     )
 
     setup_test_dir(testdir)
+    SampleGenerator.clean_samples()
+    Rule.clean_rules()
+
     # run pytest with the following cmd args
     result = testdir.runpytest(
         "--splunk-type=docker", "-v",
@@ -128,6 +133,9 @@ def test_splunk_app_fiction(testdir):
     )
 
     setup_test_dir(testdir)
+    SampleGenerator.clean_samples()
+    Rule.clean_rules()
+
     # run pytest with the following cmd args
     result = testdir.runpytest(
         "--splunk-type=docker",  "-v", "-m splunk_searchtime_fields","--search-interval=4","--search-retry=4","--search-index=*,_internal",
@@ -159,6 +167,8 @@ def test_splunk_app_broken(testdir):
         os.path.join(testdir.tmpdir, "package"),
     )
     setup_test_dir(testdir)
+    SampleGenerator.clean_samples()
+    Rule.clean_rules()
 
     # run pytest with the following cmd args
     result = testdir.runpytest(
@@ -202,6 +212,8 @@ def test_splunk_app_cim_fiction(testdir):
     )
 
     setup_test_dir(testdir)
+    SampleGenerator.clean_samples()
+    Rule.clean_rules()
 
     # run pytest with the following cmd args
     result = testdir.runpytest(
@@ -245,6 +257,8 @@ def test_splunk_app_cim_broken(testdir):
     )
 
     setup_test_dir(testdir)
+    SampleGenerator.clean_samples()
+    Rule.clean_rules()
 
     # run pytest with the following cmd args
     result = testdir.runpytest(
@@ -373,6 +387,8 @@ def test_splunk_setup_fixture(testdir):
         """
     )
     setup_test_dir(testdir)
+    SampleGenerator.clean_samples()
+    Rule.clean_rules()
     with open(
         os.path.join(
             testdir.request.fspath.dirname,


### PR DESCRIPTION
This PR contains:

- Updated list of input_type to ["file_monitor", "scripted_input", "default"] so as to avoid Encoding issue in other input_type.

-  Also, updated count in getFieldValueList function to return maximum of 4000 events.

-  Also, added clean_samples and clean_rules method for all the Github Actions tests so as to avoid usage of splunk with old events.