### PR TITLE
[fix] Handle situations where a TRANSFORMS REGEX uses _VAL

### DIFF
--- a/pytest_splunk_addon/standard_lib/addon_parser/transforms_parser.py
+++ b/pytest_splunk_addon/standard_lib/addon_parser/transforms_parser.py
@@ -5,11 +5,13 @@ Provides transforms.conf parsing mechanism
 import logging
 import re
 import os
-import csv 
+import csv
 from urllib.parse import unquote
+
 LOGGER = logging.getLogger("pytest-splunk-addon")
 
 from . import convert_to_fields
+
 
 class TransformsParser(object):
     """
@@ -19,8 +21,9 @@ class TransformsParser(object):
         splunk_app_path (str): Path of the Splunk app
         app (splunk_appinspect.App): Object of Splunk app
     """
+
     def __init__(self, splunk_app_path, app):
-        self.app = app 
+        self.app = app
         self.splunk_app_path = splunk_app_path
         self._transforms = None
 
@@ -73,8 +76,10 @@ class TransformsParser(object):
             if "REGEX" in transforms_section.options:
                 LOGGER.info("Parsing REGEX of %s", transforms_stanza)
 
-                regex = r"\(\?P?(?:[<'])([^\>'\s]+)[\>']"
-                match_fields = re.findall(regex, transforms_section.options["REGEX"].value)
+                regex = r"\(\?\<(?!_KEY|_VAL)([A-Za-z0-9_]+)\>"
+                match_fields = re.findall(
+                    regex, transforms_section.options["REGEX"].value
+                )
                 for each_field in match_fields:
                     if not each_field.startswith(("_KEY_", "_VAL_")):
                         yield each_field.strip()
@@ -87,7 +92,9 @@ class TransformsParser(object):
             if "FORMAT" in transforms_section.options:
                 LOGGER.info("Parsing FORMAT of %s", transforms_stanza)
                 regex = r"(\S*)::"
-                match_fields = re.findall(regex, transforms_section.options["FORMAT"].value)
+                match_fields = re.findall(
+                    regex, transforms_section.options["FORMAT"].value
+                )
                 for each_field in match_fields:
                     if not "$" in each_field:
                         yield each_field.strip()

--- a/tests/addons/TA_fiction/default/props.conf
+++ b/tests/addons/TA_fiction/default/props.conf
@@ -84,7 +84,9 @@ REPORT-fiction-tsc-sk-delim-format = fiction-tsc-sk-delim-format
 
 ## multiple transforms stanza associated with REPORT
 REPORT-fiction-tsc-regex-format = fiction-tsc-regex, fiction-tsc-regex-format
-
+## Report stanza using dynamic key names
+REPORT-fiction-tsc-regex-key-n = fiction-tsc-regex-key-n
+REPORT-fiction-tsc-regex-key-complex-n = fiction-tsc-regex-key-complex-n
 
 # Component tested: sourcetype, EVAL
 # Scenario: Data must be present in the respective sourcetype=splunkd

--- a/tests/addons/TA_fiction/default/props.conf
+++ b/tests/addons/TA_fiction/default/props.conf
@@ -85,8 +85,8 @@ REPORT-fiction-tsc-sk-delim-format = fiction-tsc-sk-delim-format
 ## multiple transforms stanza associated with REPORT
 REPORT-fiction-tsc-regex-format = fiction-tsc-regex, fiction-tsc-regex-format
 ## Report stanza using dynamic key names
-REPORT-fiction-tsc-regex-key-n = fiction-tsc-regex-key-n
-REPORT-fiction-tsc-regex-key-complex-n = fiction-tsc-regex-key-complex-n
+#REPORT-fiction-tsc-regex-key-n = fiction-tsc-regex-key-n
+REPORT-fiction-tsc-regex-key-complex-n = fiction-tsc-regex-key-complex-n, fiction-tsc-regex-key-n
 
 # Component tested: sourcetype, EVAL
 # Scenario: Data must be present in the respective sourcetype=splunkd

--- a/tests/addons/TA_fiction/default/transforms.conf
+++ b/tests/addons/TA_fiction/default/transforms.conf
@@ -43,3 +43,11 @@ FORMAT = size1::$1 size2::$2
 [fiction-tsc-regex]
 REGEX = group=(?<extractone>[^,]+)
 
+# Component tested: REPORT, REGEX
+# Scenario: Check for Dynamically Named captured groups in Regex
+# Do not test this condition using field searches
+[fiction-tsc-regex-key-n]
+REGEX = (?:^| )(?<_KEY_1>[^=]*)=(?! )(?<_VAL_1>.+?)(?=(?: [^ ]*(?<!\\)=|$))
+
+[fiction-tsc-regex-key-complex-n]
+REGEX = c(c6a|f|n|s)(\d)Label=(?<_KEY_1>.+?)(?=(?: [^ ]*(?<!\\)=|$))(?=.*c\1\2=(?<_VAL_1>.+?)(?=(?: [^ ]*(?<!\\)=|$)))

--- a/tests/addons/TA_fiction/default/transforms.conf
+++ b/tests/addons/TA_fiction/default/transforms.conf
@@ -47,7 +47,7 @@ REGEX = group=(?<extractone>[^,]+)
 # Scenario: Check for Dynamically Named captured groups in Regex
 # Do not test this condition using field searches
 [fiction-tsc-regex-key-n]
-REGEX = (?:^| )(?<_KEY_1>[^=]*)=(?! )(?<_VAL_1>.+?)(?=(?: [^ ]*(?<!\\)=|$))
+REGEX = (?:^| )(?<_KEY_1>XXXXXX[^=]*)=(?! )(?<_VAL_1>.+?)(?=(?: [^ ]*(?<!\\)=|$))
 
 [fiction-tsc-regex-key-complex-n]
 REGEX = c(c6a|f|n|s)(\d)Label=(?<_KEY_1>.+?)(?=(?: [^ ]*(?<!\\)=|$))(?=.*c\1\2=(?<_VAL_1>.+?)(?=(?: [^ ]*(?<!\\)=|$)))


### PR DESCRIPTION
Handle more complex syntax of regex to capture only valid named capture groups