### PR TITLE
Base 6523 updates to fields in change model

### DIFF
--- a/pytest_splunk_addon/standard_lib/data_models/Change.json
+++ b/pytest_splunk_addon/standard_lib/data_models/Change.json
@@ -11,16 +11,7 @@
         {
           "name": "action",
           "type": "required",
-          "expected_values": [
-            "created",
-            "deleted",
-            "acl_modified",
-            "cleared",
-            "modified",
-            "read",
-            "stopped",
-            "updated"
-          ],
+          "validity": "if(like(action,'%\\\"%'),null(),action)",
           "comment": "The action performed on the resource."
         },
         {
@@ -51,23 +42,26 @@
         {
           "name": "object_attrs",
           "multi_value": true,
+          "validity": "if(like(action,'%\\\"%'),null(),action)",
           "type": "required",
           "comment": "The attributes that were updated on the updated resource object, if applicable."
         },
         {
           "name": "object_category",
+          "validity": "if(like(action,'%\\\"%'),null(),action)",
           "type": "required",
-          "validity": "if(match(object_category,\"^[a-z_]+$\"),object_category,null())",
           "comment": "Generic name for the class of the updated resource object. Expected values may be specific to an app."
         },
         {
           "name": "object_id",
+          "validity": "if(like(action,'%\\\"%'),null(),action)",
           "type": "required",
           "comment": "The unique updated resource object ID as presented to the system, if applicable (for instance, a SID, UUID, or GUID value)."
         },
         {
           "name": "object_path",
-          "type": "optional",
+          "validity": "if(like(action,'%\\\"%'),null(),action)",
+          "type": "required",
           "comment": "The path of the modified resource object, if applicable (such as a file, directory, or volume)."
         },
         {

--- a/pytest_splunk_addon/standard_lib/data_models/Change.json
+++ b/pytest_splunk_addon/standard_lib/data_models/Change.json
@@ -42,25 +42,25 @@
         {
           "name": "object_attrs",
           "multi_value": true,
-          "validity": "if(like(action,'%\\\"%'),null(),action)",
+          "validity": "if(like(object_attrs,'%\\\"%'),null(),object_attrs)",
           "type": "required",
           "comment": "The attributes that were updated on the updated resource object, if applicable."
         },
         {
           "name": "object_category",
-          "validity": "if(like(action,'%\\\"%'),null(),action)",
+          "validity": "if(like(object_category,'%\\\"%'),null(),object_category)",
           "type": "required",
           "comment": "Generic name for the class of the updated resource object. Expected values may be specific to an app."
         },
         {
           "name": "object_id",
-          "validity": "if(like(action,'%\\\"%'),null(),action)",
+          "validity": "if(like(object_id,'%\\\"%'),null(),object_id)",
           "type": "required",
           "comment": "The unique updated resource object ID as presented to the system, if applicable (for instance, a SID, UUID, or GUID value)."
         },
         {
           "name": "object_path",
-          "validity": "if(like(action,'%\\\"%'),null(),action)",
+          "validity": "if(like(object_path,'%\\\"%'),null(),object_path)",
           "type": "required",
           "comment": "The path of the modified resource object, if applicable (such as a file, directory, or volume)."
         },


### PR DESCRIPTION
- Changed the Change Datamodel to make action, object_attrs, object_category, object_id, and object_path fields required, and checking that the field is not a finite list and that the value is not empty,- space or contain quotes. 
- This fulfills the requirements for: https://jira.splunk.com/browse/BASE-6527 and https://jira.splunk.com/browse/BASE-6523