### PR TITLE
Acd 4518 add tokenised events into log files

### DIFF
--- a/docs/how_to_use.rst
+++ b/docs/how_to_use.rst
@@ -125,6 +125,12 @@ The following optional arguments are available to modify the default settings in
 
                 Time interval to wait before retrying the search query.Default value: 0.
 
+    3. To discard the eventlog generation in the working directory, user can provide following additional argument along with pytest command:
+
+        .. code-block:: console
+
+            --discard-eventlogs
+
 
 Extending pytest-splunk-addon
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/index_time_tests.rst
+++ b/docs/index_time_tests.rst
@@ -159,7 +159,7 @@ FAQ
 ----
 
 1. What is the source of data used while testing with pytest-splunk-addon 1.3.0 and above?
-    * pytest-splunk-addon relies on samples available in addon available in samples folder under path provided ``--splunk-app`` or ``--splunk-data-generator`` options.
+    * pytest-splunk-addon relies on samples available in addon folder under path provided ``--splunk-app`` or ``--splunk-data-generator`` options.
 2. When do I assign timestamp_type = event to test the time extraction (_time) for a stanza?
     * When the Splunk assigns _time value from a timestamp present in event based on props configurations, you should assign ``timestamp_type=event`` for that sample stanza.
     * Example: 
@@ -207,7 +207,7 @@ FAQ
           token.0.replacementType = random
           token.0.replacement = host["host"]
           token.0.field = host
-6. Can I assign test any field present in my event as Key Field in Key Fields tests?
+6. Can I test any field present in my event as Key Field in Key Fields tests?
     * No, Key Fields are defined in plugin and only below fields can be validated as part of Key Field tests.
 
       * src

--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -211,12 +211,10 @@ def pytest_addoption(parser):
         help="Create a markdown report summarizing CIM compliance. Provide a relative or absolute path where the report should be created",
     )
     group.addoption(
-        "--store-events",
-        action="store",
+        "--discard-eventlogs",
+        action="store_false",
         dest="store_events",
-        default=False,
-        help="Creates a json file for each of the stanza present in pytest-splunk-addon-data.conf and stores the events after tokenisation and other related info in the json file."
-            "Accepts True/False",
+        help="Avoids generation of the json files with the tokenised events in the working directory."
     )
 
 

--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -210,6 +210,14 @@ def pytest_addoption(parser):
         dest="cim_report",
         help="Create a markdown report summarizing CIM compliance. Provide a relative or absolute path where the report should be created",
     )
+    group.addoption(
+        "--store-events",
+        action="store",
+        dest="store_events",
+        default=False,
+        help="Creates a json file for each of the stanza present in pytest-splunk-addon-data.conf and stores the events after tokenisation and other related info in the json file."
+            "Accepts True/False",
+    )
 
 
 @pytest.fixture(scope="session")
@@ -513,7 +521,8 @@ def splunk_ingest_data(request, splunk_hec_uri, sc4s):
             "sc4s_port": sc4s[1][514]  # for sc4s
         }
         thread_count = int(request.config.getoption("thread_count"))
-        IngestorHelper.ingest_events(ingest_meta_data, addon_path, config_path, thread_count)
+        store_events = request.config.getoption("store_events")
+        IngestorHelper.ingest_events(ingest_meta_data, addon_path, config_path, thread_count, store_events)
         sleep(50)
         if ("PYTEST_XDIST_WORKER" in os.environ):
             with open(os.environ.get("PYTEST_XDIST_TESTRUNUID") + "_wait", "w+"):

--- a/pytest_splunk_addon/standard_lib/app_test_generator.py
+++ b/pytest_splunk_addon/standard_lib/app_test_generator.py
@@ -86,7 +86,7 @@ class AppTestGenerator(object):
                         store_events,
                         app_path=app_path,
                         config_path=config_path,
-                        test_type="key_fields",
+                        test_type="key_fields"
                         )
                 )
 
@@ -96,7 +96,7 @@ class AppTestGenerator(object):
                         store_events,
                         app_path=app_path,
                         config_path=config_path,
-                        test_type="_time",
+                        test_type="_time"
                         )
                 )
 
@@ -106,7 +106,7 @@ class AppTestGenerator(object):
                         store_events,
                         app_path=app_path,
                         config_path=config_path,
-                        test_type="line_breaker",
+                        test_type="line_breaker"
                         )
                 )
             if isinstance(pytest_params, str):

--- a/pytest_splunk_addon/standard_lib/app_test_generator.py
+++ b/pytest_splunk_addon/standard_lib/app_test_generator.py
@@ -61,7 +61,8 @@ class AppTestGenerator(object):
 
         Args:
             fixture(str): fixture name
-        """
+        """ 
+        store_events = self.pytest_config.getoption("store_events")
         if fixture.startswith("splunk_searchtime_fields"):
             yield from self.dedup_tests(
                 self.fieldtest_generator.generate_tests(fixture), fixture
@@ -82,27 +83,30 @@ class AppTestGenerator(object):
             if "key_fields" in fixture:
                 pytest_params = list(
                     self.indextime_test_generator.generate_tests(
+                        store_events,
                         app_path=app_path,
                         config_path=config_path,
-                        test_type="key_fields"
+                        test_type="key_fields",
                         )
                 )
 
             elif "_time" in fixture:
                 pytest_params = list(
                     self.indextime_test_generator.generate_tests(
+                        store_events,
                         app_path=app_path,
                         config_path=config_path,
-                        test_type="_time"
+                        test_type="_time",
                         )
                 )
 
             elif "line_breaker" in fixture:
                 pytest_params = list(
                     self.indextime_test_generator.generate_tests(
+                        store_events,
                         app_path=app_path,
                         config_path=config_path,
-                        test_type="line_breaker"
+                        test_type="line_breaker",
                         )
                 )
             if isinstance(pytest_params, str):

--- a/pytest_splunk_addon/standard_lib/event_ingestors/ingestor_helper.py
+++ b/pytest_splunk_addon/standard_lib/event_ingestors/ingestor_helper.py
@@ -30,7 +30,7 @@ class IngestorHelper(object):
         return ingestor
 
     @classmethod
-    def ingest_events(cls, ingest_meta_data, addon_path, config_path, thread_count):
+    def ingest_events(cls, ingest_meta_data, addon_path, config_path, thread_count, store_events):
         """
         Events are ingested in the splunk.
         Args:
@@ -41,7 +41,7 @@ class IngestorHelper(object):
 
         """
         sample_generator = SampleXdistGenerator(addon_path, config_path)
-        store_sample = sample_generator.get_samples()
+        store_sample = sample_generator.get_samples(store_events)
         tokenized_events = store_sample.get("tokenized_events")
         ingestor_dict = dict()
         for event in tokenized_events:

--- a/pytest_splunk_addon/standard_lib/index_tests/test_generator.py
+++ b/pytest_splunk_addon/standard_lib/index_tests/test_generator.py
@@ -17,7 +17,7 @@ class IndexTimeTestGenerator(object):
       for the Add-on.
     """
 
-    def generate_tests(self, app_path, config_path, test_type):
+    def generate_tests(self, store_events, app_path, config_path, test_type):
         """
         Generates the test cases based on test_type 
 
@@ -31,9 +31,8 @@ class IndexTimeTestGenerator(object):
 
         """
         sample_generator = SampleXdistGenerator(app_path, config_path)
-        store_sample = sample_generator.get_samples()
+        store_sample = sample_generator.get_samples(store_events)
         tokenized_events = store_sample.get("tokenized_events")
-
         if not store_sample.get("conf_name") == "psa-data-gen":
             return " Index Time tests cannot be executed using eventgen.conf,\
                  pytest-splunk-addon-data.conf is required."

--- a/pytest_splunk_addon/standard_lib/sample_generation/sample_xdist_generator.py
+++ b/pytest_splunk_addon/standard_lib/sample_generation/sample_xdist_generator.py
@@ -3,6 +3,7 @@ from . import SampleGenerator
 import os
 import pickle
 from filelock import FileLock
+import json
 
 class SampleXdistGenerator():
 
@@ -11,7 +12,7 @@ class SampleXdistGenerator():
         self.process_count = process_count
         self.config_path = config_path
 
-    def get_samples(self):
+    def get_samples(self, store_events):
         if "PYTEST_XDIST_WORKER" in os.environ:
             file_path = os.environ.get("PYTEST_XDIST_TESTRUNUID") + "_events"
             with FileLock(str(file_path) + ".lock"):
@@ -22,6 +23,8 @@ class SampleXdistGenerator():
                     sample_generator = SampleGenerator(
                         self.addon_path, self.config_path)
                     tokenized_events = list(sample_generator.get_samples())
+                    if store_events:
+                        self.store_events(tokenized_events)
                     store_sample = {"conf_name" : SampleGenerator.conf_name, "tokenized_events" : tokenized_events}
                     with open(file_path, "wb") as file_obj:
                         pickle.dump(store_sample, file_obj)
@@ -30,4 +33,46 @@ class SampleXdistGenerator():
                 self.addon_path, self.config_path)
             tokenized_events = list(sample_generator.get_samples())
             store_sample = {"conf_name" : SampleGenerator.conf_name, "tokenized_events" : tokenized_events}
+            if store_events:
+                self.store_events(tokenized_events)
         return store_sample
+
+    def store_events(self, tokenized_events):
+        if not os.path.exists(os.path.join(os.getcwd(),"tokenized_events")):
+            os.makedirs(os.path.join(os.getcwd(),"tokenized_events"))
+        tokenized_samples_dict = {}
+        for each_event in tokenized_events:
+            if each_event.sample_name not in tokenized_samples_dict:
+                if each_event.metadata.get("input_type") not in [
+                        "modinput",
+                        "windows_input",
+                    ]:
+                        expected_count = int(each_event.metadata.get("expected_event_count")) * int(each_event.metadata.get("sample_count"))
+                else:
+                    expected_count = each_event.metadata.get("expected_event_count")
+                tokenized_samples_dict[each_event.sample_name] = {
+                    "metadata": {
+                        "host": each_event.metadata.get("host"),
+                        "source": each_event.metadata.get("source"),
+                        "sourcetype": each_event.metadata.get("sourcetype"),
+                        "timestamp_type": each_event.metadata.get("timestamp_type"),
+                        "input_type": each_event.metadata.get("input_type"),
+                        "expected_event_count": expected_count
+                    },
+                    "events":[{
+                        "event":each_event.event,
+                        "key_fields":each_event.key_fields,
+                        "time_values":each_event.time_values
+                    }],
+                }
+            else:
+                tokenized_samples_dict[each_event.sample_name]["events"].append({
+                    "event":each_event.event,
+                    "key_fields":each_event.key_fields,
+                    "time_values":each_event.time_values
+                })
+
+        for sample_name,tokenized_sample in tokenized_samples_dict.items():
+            with open("{}.json".format(os.path.join(os.getcwd(),"tokenized_events",sample_name)), "w") as eventfile:
+                eventfile.write(json.dumps({sample_name:tokenized_sample}, indent="\t"))
+        

--- a/pytest_splunk_addon/standard_lib/sample_generation/sample_xdist_generator.py
+++ b/pytest_splunk_addon/standard_lib/sample_generation/sample_xdist_generator.py
@@ -23,9 +23,9 @@ class SampleXdistGenerator():
                     sample_generator = SampleGenerator(
                         self.addon_path, self.config_path)
                     tokenized_events = list(sample_generator.get_samples())
+                    store_sample = {"conf_name" : SampleGenerator.conf_name, "tokenized_events" : tokenized_events}
                     if store_events:
                         self.store_events(tokenized_events)
-                    store_sample = {"conf_name" : SampleGenerator.conf_name, "tokenized_events" : tokenized_events}
                     with open(file_path, "wb") as file_obj:
                         pickle.dump(store_sample, file_obj)
         else:  

--- a/pytest_splunk_addon/standard_lib/sample_generation/sample_xdist_generator.py
+++ b/pytest_splunk_addon/standard_lib/sample_generation/sample_xdist_generator.py
@@ -38,8 +38,8 @@ class SampleXdistGenerator():
         return store_sample
 
     def store_events(self, tokenized_events):
-        if not os.path.exists(os.path.join(os.getcwd(),"tokenized_events")):
-            os.makedirs(os.path.join(os.getcwd(),"tokenized_events"))
+        if not os.path.exists(os.path.join(os.getcwd(),".tokenized_events")):
+            os.makedirs(os.path.join(os.getcwd(),".tokenized_events"))
         tokenized_samples_dict = {}
         for each_event in tokenized_events:
             if each_event.sample_name not in tokenized_samples_dict:
@@ -73,6 +73,6 @@ class SampleXdistGenerator():
                 })
 
         for sample_name,tokenized_sample in tokenized_samples_dict.items():
-            with open("{}.json".format(os.path.join(os.getcwd(),"tokenized_events",sample_name)), "w") as eventfile:
+            with open("{}.json".format(os.path.join(os.getcwd(),".tokenized_events",sample_name)), "w") as eventfile:
                 eventfile.write(json.dumps({sample_name:tokenized_sample}, indent="\t"))
         


### PR DESCRIPTION
- Updated the code to store the tokenised events for each stanza present in pytest-splunk-addon-data.conf, in the working directory.
- For each stanza present, a json file will be generated under the directory `.tokenized_events` with the events, key_fields and other related metadata
- Json files will be generated even if tests are not executed and --collect-only is used.
- To avoid generating these json files user can provide `--discard-eventlogs` param with the pytest command.

