### PR TITLE
ACD-4535-Added support for custom indexes in pytest-splunk-addon-data.conf file

### DIFF
--- a/pytest_splunk_addon/standard_lib/event_ingestors/hec_event_ingestor.py
+++ b/pytest_splunk_addon/standard_lib/event_ingestors/hec_event_ingestor.py
@@ -76,6 +76,7 @@ class HECEventIngestor(EventIngestor):
                 "source": event.metadata.get("source",
                                              "pytest_splunk_addon:hec:event"),
                 "event": event.event,
+                "index": event.metadata.get("index", "main")
             }
 
             if event.metadata.get("host_type") in ("plugin", None):

--- a/pytest_splunk_addon/standard_lib/event_ingestors/hec_raw_ingestor.py
+++ b/pytest_splunk_addon/standard_lib/event_ingestors/hec_raw_ingestor.py
@@ -70,6 +70,7 @@ class HECRawEventIngestor(EventIngestor):
             event_dict = {
                 "sourcetype": event.metadata.get('sourcetype', 'pytest_splunk_addon'),
                 "source": event.metadata.get('source', 'pytest_splunk_addon:hec:raw'),
+                "index": event.metadata.get('index', 'main'),
             }
 
             if event.metadata.get("host"):

--- a/pytest_splunk_addon/standard_lib/sample_generation/sample_stanza.py
+++ b/pytest_splunk_addon/standard_lib/sample_generation/sample_stanza.py
@@ -157,6 +157,8 @@ class SampleStanza(object):
         if metadata.get("count") and not metadata.get("count").isnumeric():
             raise_warning("Invalid value for count: '{}' using count = 1.".format(metadata.get("count")))
             metadata.update(count="100")
+        if metadata.get("index") is not None and metadata.get("input_type") in ["syslog_tcp", "tcp", "udp"]:
+            raise_warning("For input_type '{}', there should be no index set".format(metadata.get("input_type")))
         return metadata
 
     def get_eventmetadata(self):

--- a/pytest_splunk_addon/standard_lib/sample_generation/sample_xdist_generator.py
+++ b/pytest_splunk_addon/standard_lib/sample_generation/sample_xdist_generator.py
@@ -57,7 +57,8 @@ class SampleXdistGenerator():
                         "sourcetype": each_event.metadata.get("sourcetype"),
                         "timestamp_type": each_event.metadata.get("timestamp_type"),
                         "input_type": each_event.metadata.get("input_type"),
-                        "expected_event_count": expected_count
+                        "expected_event_count": expected_count,
+                        "index": each_event.metadata.get("index", "main")
                     },
                     "events":[{
                         "event":each_event.event,


### PR DESCRIPTION
ACD-4535
- Added support for ingesting data into custom indexes specified by the user within pytest-splunk-addon-data.conf files. 
- Added a warning message if a user tries to define index while using TCP/UDP/SC4S input type