### PR TITLE
ACD-4543 Adds forwarder host params

### DIFF
--- a/docs/how_to_use.rst
+++ b/docs/how_to_use.rst
@@ -90,10 +90,7 @@ The tool assumes the Splunk Add-on is located in a folder "package" in the proje
             --splunk-port=<splunk_management_port>                      # default 8089
             --splunk-user=<username>                                    # default admin     
             --splunk-password=<password>                                # default Chang3d!
-            --splunk-forwarder-host=<splunk_forwarder_host>             # Splunk instance where forwarding to receiver instance is configured.
-            --splunk-forwarder-port=<splunk_forwarder_port>             # default 8089
-            --splunk-forwarder-user=<splunk_forwarder_user>             # default admin
-            --splunk-forwarder-password=<splunk_forwarder_password>     # default Chang3d!                
+            --splunk-forwarder-host=<splunk_forwarder_host>             # Splunk instance where forwarding to receiver instance is configured.                
             --splunk-hec-port=<splunk_forwarder_hec_port>               # HEC port of the forwarder instance.
             --splunk-hec-token=<splunk_forwarder_hec_token>             # HEC token configured in forwarder instance.
             --splunk-data-generator=<pytest_splunk_addon_conf_path>     # Path to pytest-splunk-addon-data.conf

--- a/docs/how_to_use.rst
+++ b/docs/how_to_use.rst
@@ -72,7 +72,7 @@ The tool assumes the Splunk Add-on is located in a folder "package" in the proje
 
 **3. Running tests with an external forwarder and Splunk instance**
 
-    * Run pytest with the add-on, using an external forwarder sending events to another Splunk deployment or Cloud Stack where a user can search for recieved events.
+    * Run pytest with the add-on, using an external forwarder sending events to another Splunk deployment where a user can search for received events.
     * Forwarding & receiving configuration in --splunk-forwarder-host and --splunk-host must be done before executing the tests.
     * User must test using makeresults command if forwarding & receiving is properly configured or not.
 

--- a/docs/how_to_use.rst
+++ b/docs/how_to_use.rst
@@ -69,6 +69,39 @@ The tool assumes the Splunk Add-on is located in a folder "package" in the proje
    * From v1.3.0 pytest-splunk-addon ingests data independently which is used for execution of all the test cases.
 
 
+
+**3. Running tests with an external forwarder and Splunk instance**
+
+    * Run pytest with the add-on, using an external forwarder sending events to another Splunk deployment or Cloud Stack where a user can search for recieved events.
+    * Forwarding & receiving configuration in --splunk-forwarder-host and --splunk-host must be done before executing the tests.
+    * User must test using makeresults command if forwarding & receiving is properly configured or not.
+
+    .. code:: bash
+
+        | makeresults | eval _raw="sample event" | collect index=main, source=test_source, sourcetype=test_src_type
+
+    * Sample pytest command with the required params
+    .. code:: bash
+
+        pytest --splunk-type=external 
+            --splunk-app=<path-to-addon-package> 
+            --splunk-host=<hostname>                                    # Receiver Splunk instance where events are searchable.
+            --splunk-port=<splunk_management_port>                      # default 8089
+            --splunk-user=<username>                                    # default admin     
+            --splunk-password=<password>                                # default Chang3d!
+            --splunk-forwarder-host=<splunk_forwarder_host>             # Splunk instance where forwarding to receiver instance is configured.
+            --splunk-forwarder-port=<splunk_forwarder_port>             # default 8089
+            --splunk-forwarder-user=<splunk_forwarder_user>             # default admin
+            --splunk-forwarder-password=<splunk_forwarder_password>     # default Chang3d!                
+            --splunk-hec-port=<splunk_forwarder_hec_port>               # HEC port of the forwarder instance.
+            --splunk-hec-token=<splunk_forwarder_hec_token>             # HEC token configured in forwarder instance.
+            --splunk-data-generator=<pytest_splunk_addon_conf_path>     # Path to pytest-splunk-addon-data.conf
+
+.. note::
+   * Forwarder params are supported only for external splunk-type.
+   * If Forwarder params are not provided It will ingest and search in the same Splunk deployment provided in --splunk-host param.
+
+
 ----------------------
 
 There are 3 types of tests included in pytest-splunk-addon are:

--- a/docs/how_to_use.rst
+++ b/docs/how_to_use.rst
@@ -74,7 +74,7 @@ The tool assumes the Splunk Add-on is located in a folder "package" in the proje
 
     * Run pytest with the add-on, using an external forwarder sending events to another Splunk deployment where a user can search for received events.
     * Forwarding & receiving configuration in --splunk-forwarder-host and --splunk-host must be done before executing the tests.
-    * User must test using makeresults command if forwarding & receiving is properly configured or not.
+    * User can validate the forwarding using makeresults command.
 
     .. code:: bash
 

--- a/docs/how_to_use.rst
+++ b/docs/how_to_use.rst
@@ -81,6 +81,7 @@ The tool assumes the Splunk Add-on is located in a folder "package" in the proje
         | makeresults | eval _raw="sample event" | collect index=main, source=test_source, sourcetype=test_src_type
 
     * Sample pytest command with the required params
+    
     .. code:: bash
 
         pytest --splunk-type=external 

--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -390,6 +390,11 @@ def splunk_docker(
         "password": request.config.getoption("splunk_password"),
     }
 
+    splunk_info["forwarder_host"] = splunk_info.get("host")
+    splunk_info["forwarder_port"] = splunk_info.get("port")
+    splunk_info["forwarder_username"] = splunk_info.get("username")
+    splunk_info["forwarder_password"] = splunk_info.get("password")
+
     LOGGER.info(
         "Docker container splunk info. host=%s, port=%s, port_web=%s port_hec=%s port_s2s=%s",
         docker_services.docker_ip,

--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -499,8 +499,8 @@ def splunk_rest_uri(splunk):
     Provides a uri to the Splunk rest port
     """
     splunk_session = requests.Session()
-    splunk_session.auth = (splunk["forwarder_username"], splunk["forwarder_password"])
-    uri = f'https://{splunk["forwarder_host"]}:{splunk["port_hec"]}/'
+    splunk_session.auth = (splunk["username"], splunk["password"])
+    uri = f'https://{splunk["host"]}:{splunk["port"]}/'
     LOGGER.info("Fetched splunk_rest_uri=%s", uri)
 
     return splunk_session, uri


### PR DESCRIPTION
* This PR contains the code for testing addons with an external forwarder host sending events to another Splunk deployment  where a user can search for received events.
* Four new pytest params are added to achieve the functionality
* Sample pytest command

            pytest --splunk-type=external 
            --splunk-app=<path-to-addon-package> 
            --splunk-host=<hostname>                                    # Receiver Splunk instance where events are searchable.
            --splunk-port=<splunk_management_port>                      # default 8089
            --splunk-user=<username>                                    # default admin     
            --splunk-password=<password>                                # default Chang3d!
            --splunk-forwarder-host=<splunk_forwarder_host>             # Splunk instance where forwarding to receiver instance is configured.            
            --splunk-hec-port=<splunk_forwarder_hec_port>               # HEC port of the forwarder instance.
            --splunk-hec-token=<splunk_forwarder_hec_token>             # HEC token configured in forwarder instance.
            --splunk-data-generator=<pytest_splunk_addon_conf_path>     # Path to pytest-splunk-addon-data.conf

* Forwarder params are supported only for **external** splunk-type.
* Forwarding & receiving configuration in --splunk-forwarder-host and --splunk-host must be done before executing the tests.
* If Forwarder params are not provided It will ingest and search in the same Splunk deployment provided in --splunk-host param.
