### PR TITLE
INFRA-27682 Suppress internal errors

### DIFF
--- a/docs/how_to_use.rst
+++ b/docs/how_to_use.rst
@@ -167,7 +167,33 @@ The following optional arguments are available to modify the default settings in
         .. code-block:: console
 
             --no-splunk-cleanup
+    
+    5. A new functionality is introduced in pytest-splunk-addon to suppress unwanted errors in **test_splunk_internal_errors**.
 
+            - **Splunk related errors**: There is a file maintained in pytest-splunk-addon `".ignore_splunk_internal_errors" <https://github.com/splunk/pytest-splunk-addon/blob/develop/.ignore_splunk_internal_errors>`_ , user can add the string in the file and events cantaining these strings will be suppressed by the search query.
+            - **Addon related errors:** To suppress these user can create a file with the list of strings and provide the file in the **--ignore-addon-errors** param while test execution.
+
+        .. code-block:: console
+
+            --ignore-addon-errors=<path_to_file>
+                
+        - Sample strings in the file.
+
+        .. code-block:: console
+
+            SearchMessages - orig_component="SearchStatusEnforcer"
+            message_key="" message=NOT requires an argument
+
+        .. Note ::
+            *Each line in the file will be considered a separate string to be ignored in the events.*
+        
+        - Sample Event which will be ignored by the search query.
+        
+        .. code-block:: console
+
+            11-04-2020 13:26:01.026 +0000 ERROR SearchMessages - orig_component="SearchStatusEnforcer" app="search" sid="ta_1604496283.232" peer_name="" message_key="" message=NOT requires an argument
+        
+    
 
 Extending pytest-splunk-addon
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/how_to_use.rst
+++ b/docs/how_to_use.rst
@@ -170,7 +170,7 @@ The following optional arguments are available to modify the default settings in
     
     5. A new functionality is introduced in pytest-splunk-addon to suppress unwanted errors in **test_splunk_internal_errors**.
 
-            - **Splunk related errors**: There is a file maintained in pytest-splunk-addon `".ignore_splunk_internal_errors" <https://github.com/splunk/pytest-splunk-addon/blob/develop/.ignore_splunk_internal_errors>`_ , user can add the string in the file and events cantaining these strings will be suppressed by the search query.
+            - **Splunk related errors**: There is a file maintained in pytest-splunk-addon `".ignore_splunk_internal_errors" <https://github.com/splunk/pytest-splunk-addon/blob/develop/pytest_splunk_addon/.ignore_splunk_internal_errors>`_ , user can add the string in the file and events containing these strings will be suppressed by the search query.
             - **Addon related errors:** To suppress these user can create a file with the list of strings and provide the file in the **--ignore-addon-errors** param while test execution.
 
         .. code-block:: console

--- a/pytest_splunk_addon/.ignore_splunk_internal_errors
+++ b/pytest_splunk_addon/.ignore_splunk_internal_errors
@@ -1,0 +1,1 @@
+message_key="INPUT_CSV:INVALID_LOOKUP_TABLE_TYPE" message=The lookup table 'dmc_assets' requires a .csv or KV store lookup definition.

--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -300,7 +300,7 @@ def splunk_search_util(splunk, splunk_setup, request):
     return search_util
 
 @pytest.fixture(scope="session")
-def suppress_internal_errors(request):
+def ignore_internal_errors(request):
     """
     This fixture generates a common list of errors which are suppossed 
     to be ignored in test_splunk_internal_errors.

--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -238,6 +238,12 @@ def pytest_addoption(parser):
         dest="splunk_cleanup",
         help="Disable a Splunk env cleanup (events deletion) before running tests.",
     )
+    group.addoption(
+        "--ignore-addon-errors",
+        action="store",
+        dest="ignore_addon_errors",
+        help=("Path to file where list of errors to be ignored is mentioned. Default file '.ignore-errors'"),
+    )
 
 
 @pytest.fixture(scope="session")
@@ -292,6 +298,26 @@ def splunk_search_util(splunk, splunk_setup, request):
     search_util.search_interval = request.config.getoption("search_interval")
 
     return search_util
+
+@pytest.fixture(scope="session")
+def suppress_internal_errors(request):
+    """
+    This fixture generates a common list of errors which are suppossed 
+    to be ignored in test_splunk_internal_errors.
+
+    Returns:
+        dict: List of the strings to be ignored in test_splunk_internal_errors
+    """
+    error_list = []
+    splunk_error_file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),".ignore_splunk_internal_errors")
+    with open(splunk_error_file_path) as splunk_errors:
+        error_list = [each_error.strip() for each_error in splunk_errors.readlines()]
+    if request.config.getoption("ignore_addon_errors"):
+        addon_error_file_path = request.config.getoption("ignore_addon_errors")
+        if os.path.exists(addon_error_file_path):
+            with open(addon_error_file_path, "r") as addon_errors:
+                error_list.extend([each_error.strip() for each_error in addon_errors.readlines()])
+    yield error_list
 
 
 @pytest.fixture(scope="session")
@@ -440,7 +466,7 @@ def splunk_external(request):
         )
     if not is_responsive_hec(request, splunk_info):
         raise Exception(
-            "Could not connect to the external Splunk Instance"
+            "Could not connect to Splunk HEC"
             "Please check the log file for possible errors."
         )
     return splunk_info

--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -242,7 +242,7 @@ def pytest_addoption(parser):
         "--ignore-addon-errors",
         action="store",
         dest="ignore_addon_errors",
-        help=("Path to file where list of errors to be ignored is mentioned. Default file '.ignore-errors'"),
+        help=("Path to file where list of addon related errors are suppressed."),
     )
 
 

--- a/pytest_splunk_addon/standard_lib/fields_tests/test_templates.py
+++ b/pytest_splunk_addon/standard_lib/fields_tests/test_templates.py
@@ -6,6 +6,7 @@ import pprint
 import logging
 import pytest
 from ..addon_parser import Field
+import json
 
 class FieldTestTemplates(object):
     """
@@ -16,7 +17,7 @@ class FieldTestTemplates(object):
 
     @pytest.mark.splunk_searchtime_fields
     @pytest.mark.splunk_searchtime_internal_errors
-    def test_splunk_internal_errors(self, splunk_search_util, record_property, caplog):
+    def test_splunk_internal_errors(self, splunk_search_util, suppress_internal_errors, record_property, caplog):
         search = """
             search index=_internal CASE(ERROR)
             sourcetype!=splunkd_ui_access
@@ -24,8 +25,10 @@ class FieldTestTemplates(object):
             AND sourcetype!=splunk_web_service
             AND sourcetype!=splunkd_access
             AND sourcetype!=splunkd
-            | table _raw
         """
+        for each in suppress_internal_errors:
+            search += ' NOT ' + json.dumps(each)
+        search += " | table _raw"
         record_property("search", search)
         result, results = splunk_search_util.checkQueryCountIsZero(search)
         if not result:

--- a/pytest_splunk_addon/standard_lib/fields_tests/test_templates.py
+++ b/pytest_splunk_addon/standard_lib/fields_tests/test_templates.py
@@ -17,7 +17,7 @@ class FieldTestTemplates(object):
 
     @pytest.mark.splunk_searchtime_fields
     @pytest.mark.splunk_searchtime_internal_errors
-    def test_splunk_internal_errors(self, splunk_search_util, suppress_internal_errors, record_property, caplog):
+    def test_splunk_internal_errors(self, splunk_search_util, ignore_internal_errors, record_property, caplog):
         search = """
             search index=_internal CASE(ERROR)
             sourcetype!=splunkd_ui_access
@@ -26,7 +26,7 @@ class FieldTestTemplates(object):
             AND sourcetype!=splunkd_access
             AND sourcetype!=splunkd
         """
-        for each in suppress_internal_errors:
+        for each in ignore_internal_errors:
             search += ' NOT ' + json.dumps(each)
         search += " | table _raw"
         record_property("search", search)


### PR DESCRIPTION
- A new functionality is introduced in pytest-splunk-addon to suppress some unwanted errors in test_splunk_internal_errors.
- **Splunk related errors:** There is a file maintained in pytest-splunk-addon **.ignore_splunk_internal_errors** , user can add the string in the file and events cantaining these strings will be ignored by the search query.
- **Addon related errors:** To suppress these user can create a file with the list of strings and provide the file in the **--ignore-addon-errors** param while test execution.
- Each line in the file will be considered a separate string to be ignored in the events.
- Also updated the doc for the functionality

![Screenshot 2020-11-05 151650](https://user-images.githubusercontent.com/61701682/98259856-9f268280-1fa8-11eb-88b4-8ad253d2523c.jpg)

