### PR TITLE
Adding sphinx_panels to pip requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 sphinx_rtd_theme
+sphinx_panels
 -r ../requirements.txt


### PR DESCRIPTION
Adding missing sphinx_panels dependency within docs/requirements.txt file 