### PR TITLE
fix(parser): Updated the field_parser regex for pytest-splunk-addon

### DIFF
--- a/pytest_splunk_addon/standard_lib/addon_parser/props_parser.py
+++ b/pytest_splunk_addon/standard_lib/addon_parser/props_parser.py
@@ -392,7 +392,7 @@ class PropsParser(object):
                 "OUTPUT"
             )[input_output_index]
 
-            field_parser = r"(\"(?:\\\"|[^\"])*\"|\'(?:\\\'|[^\'])*\'|[^\s,]+)\s*(?:[aA][sS]\s*(\"(?:\\\"|[^\"])*\"|\'(?:\\\'|[^\'])*\'|[^\s,]+))?"
+            field_parser = r"(\"(?:\\\"|[^\"])*\"|\'(?:\\\'|[^\'])*\'|[^\s,]+)\s*(?:[aA][sS]\s+(\"(?:\\\"|[^\"])*\"|\'(?:\\\'|[^\'])*\'|[^\s,]+))?"
             # field_groups: Group of max 2 fields - (source, destination) for "source as destination"
             field_groups = re.findall(field_parser, input_output_str)
 

--- a/tests/addons/TA_broken/default/props.conf
+++ b/tests/addons/TA_broken/default/props.conf
@@ -40,6 +40,8 @@ LOOKUP-FAIL_test_no_inputfield = ta_broken_lookup OUTPUT FAIL_broken_context_tes
 # Scenario: non_existing output_field with output/outputnew so the tests for output_field will fail.
 # Expected result: FAIL
 LOOKUP-FAIL_test_wrong_output = ta_broken_lookup FAIL_component FAIL_output FAIL_non_existing
+LOOKUP-FAIL_test_wrong_as_field_name_output = ta_broken_lookup FAIL_component FAIL_output as_port as FAIL_non_existing
+LOOKUP-FAIL_test_wrong_AS_field_name_output = ta_broken_lookup FAIL_component FAIL_output AS_port as FAIL_non_existing
 LOOKUP-FAIL_test_wrong_outputnew = ta_broken_lookup FAIL_component FAIL_outputnew FAIL_non_existing_1
 
 # Component tested: LOOKUP

--- a/tests/addons/TA_fiction/default/props.conf
+++ b/tests/addons/TA_fiction/default/props.conf
@@ -168,6 +168,11 @@ LOOKUP-test_AS_keyword = ta_fiction_lookup test_name AS name OUTPUT fiction_cont
 LOOKUP-test_as_keyword = ta_fiction_lookup test_name as name OUTPUT fiction_context_test1 status_test as status2
 LOOKUP-test_as_and_AS_keyword2 = ta_fiction_lookup test_name AS name OUTPUT status_test as status2
 
+# Component tested: lookup "as" keyword is parsed correctly
+# Scenario: To test input_fields, output_fields exists or not with combinations of "as" and "AS" within their prefix.
+LOOKUP-test_as_host_keyword = ta_fiction_lookup test_name AS name OUTPUT AS_port as_host
+
+
 # Multiple input field and single output field
 LOOKUP-test_string_outputfield = ta_fiction_lookup component OUTPUTNEW status.test
 # Multiple input field and single output field

--- a/tests/addons/TA_fiction/lookups/ta_fiction_splund_component.csv
+++ b/tests/addons/TA_fiction/lookups/ta_fiction_splund_component.csv
@@ -1,4 +1,4 @@
-component ,fiction_context_test, aliasone, status_test, test_name, type, status.test, fiction_context_test1, fiction_context_test2, status2
-Metrics   ,Insights, pipeline, 200, management, splunkd, a, management1, management2, 2001
-LMStackMgr,Costs, dutycycle, 201, ingest, mongod, b, Costs1, Costs2, 2011
-HotDBManager,Stores, queue, 202, indexerpipe, splunkd_access, c, Stores1, Stores2, 2021
+component ,fiction_context_test, aliasone, status_test, test_name, type, status.test, fiction_context_test1, fiction_context_test2, status2, "as_host", "AS_port"
+Metrics   ,Insights, pipeline, 200, management, splunkd, a, management1, management2, 2001, "as_host", "AS_port"
+LMStackMgr,Costs, dutycycle, 201, ingest, mongod, b, Costs1, Costs2, 2011, "as_host", "AS_port"
+HotDBManager,Stores, queue, 202, indexerpipe, splunkd_access, c, Stores1, Stores2, 2021, "as_host", "AS_port"

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -208,6 +208,7 @@ TA_FICTION_PASSED = [
     '*test_splunk_app_fiction.py::Test_App::test_props_fields_no_dash_not_empty*splunkd::LOOKUP-test_as_input_outputnew_multiple* PASSED*',
     '*test_splunk_app_fiction.py::Test_App::test_props_fields_no_dash_not_empty*splunkd::LOOKUP-test_as_keyword* PASSED*',
     '*test_splunk_app_fiction.py::Test_App::test_props_fields_no_dash_not_empty*splunkd::LOOKUP-test_as_output* PASSED*',
+    '*test_splunk_app_fiction.py::Test_App::test_props_fields[splunkd::LOOKUP-test_as_host_keyword* PASSED*',
     '*test_splunk_app_fiction.py::Test_App::test_props_fields_no_dash_not_empty*splunkd::LOOKUP-test_command_spelling_output3* PASSED*',
     '*test_splunk_app_fiction.py::Test_App::test_props_fields_no_dash_not_empty*splunkd::LOOKUP-test_command_spelling_outputnew3* PASSED*',
     '*test_splunk_app_fiction.py::Test_App::test_props_fields_no_dash_not_empty*splunkd::LOOKUP-test_multiple_input* PASSED*',
@@ -228,6 +229,15 @@ TA_FICTION_PASSED = [
     '*test_splunk_app_fiction.py::Test_App::test_eventtype*eventtype::fiction_is_splunkd* PASSED*',
     '*test_splunk_app_fiction.py::Test_App::test_eventtype*eventtype::fiction_for_tags_positive* PASSED*',
     '*test_splunk_app_fiction.py::Test_App::test_eventtype*eventtype::fiction_is_splunkd-%host%* PASSED*',
+    '*test_splunk_app_fiction.py::Test_App::test_props_fields[splunkd::field::"as_host"* PASSED*',
+    '*test_splunk_app_fiction.py::Test_App::test_props_fields[splunkd::field::"AS_port"* PASSED*',
+    '*test_splunk_app_fiction.py::Test_App::test_props_fields[splunkd::field::AS_port* PASSED*',
+    '*test_splunk_app_fiction.py::Test_App::test_props_fields[splunkd::field::as_host* PASSED*',
+    '*test_splunk_app_fiction.py::Test_App::test_props_fields_no_dash_not_empty[splunkd::LOOKUP-test_as_host_keyword* PASSED*',
+    '*test_splunk_app_fiction.py::Test_App::test_props_fields_no_dash_not_empty[splunkd::field::"as_host"* PASSED*',
+    '*test_splunk_app_fiction.py::Test_App::test_props_fields_no_dash_not_empty[splunkd::field::as_host* PASSED*',
+    '*test_splunk_app_fiction.py::Test_App::test_props_fields_no_dash_not_empty[splunkd::field::AS_port* PASSED*',
+    '*test_splunk_app_fiction.py::Test_App::test_props_fields_no_dash_not_empty[splunkd::field::"AS_port"* PASSED*',
 ]
 
 
@@ -303,6 +313,8 @@ TA_BROKEN_PASSED = [
     '*test_splunk_app_broken.py::Test_App::test_props_fields_no_dash_not_empty*splunkd::LOOKUP-PASS_test_empty_csv* PASSED*',
     '*test_splunk_app_broken.py::Test_App::test_props_fields_no_dash_not_empty*splunkd::LOOKUP-PASS_test_lookup_not_found* PASSED*',
     '*test_splunk_app_broken.py::Test_App::test_tags*sourcetype="splunkd"::tag::tags_negative_testing* PASSED*',
+    '*test_splunk_app_broken.py::Test_App::test_props_fields_no_dash_not_empty[splunkd::LOOKUP-FAIL_test_wrong_AS_field_name_output* PASSED*',
+    '*test_splunk_app_broken.py::Test_App::test_props_fields_no_dash_not_empty[splunkd::LOOKUP-FAIL_test_wrong_as_field_name_output* PASSED*'
 ]
 
 """
@@ -358,6 +370,8 @@ TA_BROKEN_FAILED = [
     '*test_splunk_app_broken.py::Test_App::test_tags*source="/opt/splunk/var/log/splunk/splunkd.log"::tag::tags_negative_testing* FAILED*',
     '*test_splunk_app_broken.py::Test_App::test_eventtype*eventtype::broken_is_splunkd* FAILED*',
     '*test_splunk_app_broken.py::Test_App::test_eventtype*eventtype::broken_is_splunkd-%host%* FAILED*',
+    '*test_splunk_app_broken.py::Test_App::test_props_fields[splunkd::LOOKUP-FAIL_test_wrong_AS_field_name_output* FAILED*',
+    '*test_splunk_app_broken.py::Test_App::test_props_fields[splunkd::LOOKUP-FAIL_test_wrong_as_field_name_output* FAILED*'
 ]
 
 """


### PR DESCRIPTION
fix(parser): Updated the field_parser regex for pytest-splunk-addon 

Updated the parser from [aA][sS]\s* to [aA][sS]\s+ to parse prefixes using as or AS correctly.

Also added new tests to verify the fixUpdated the field_parser regex for pytest-splunk-addon from _[aA][sS]\s*_ to _[aA][sS]\s+_ to parse prefixes using as or AS correctly.