### PR TITLE
Feat add/addon 32745

### DIFF
--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -245,12 +245,10 @@ def pytest_addoption(parser):
         help=("Path to file where list of addon related errors are suppressed."),
     )
     group.addoption(
-        "--requirement_test",
-        action="store",
-        default= True,
-        type=bool,
+        "--requirement-test",
+        action="store_true",
         dest="requirement_test",
-        help=("True if requirement tests need to be run"),
+        help=("Default false use if requirement tests need to be run"),
     )
 
 

--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -577,13 +577,6 @@ def splunk_ingest_data(request, splunk_hec_uri, sc4s, splunk_events_cleanup):
         addon_path = request.config.getoption("splunk_app")
         config_path = request.config.getoption("splunk_data_generator")
         run_requirement_test = request.config.getoption("requirement_test")
-        '''
-        Add boolean input config if we need requirement tests to be run eg: requirement_tests = True/False
-        run_requirement_test = request.config.getoption("splunk_requirement_test")
-        '''
-
-        logging.info("Value " + str(addon_path))
-        logging.info("Value " + str(run_requirement_test))
         ingest_meta_data = {
             "session_headers": splunk_hec_uri[0].headers,
             "splunk_hec_uri": splunk_hec_uri[1],

--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -244,6 +244,14 @@ def pytest_addoption(parser):
         dest="ignore_addon_errors",
         help=("Path to file where list of addon related errors are suppressed."),
     )
+    group.addoption(
+        "--requirement_test",
+        action="store",
+        default= True,
+        type=bool,
+        dest="requirement_test",
+        help=("True if requirement tests need to be run"),
+    )
 
 
 @pytest.fixture(scope="session")
@@ -568,7 +576,14 @@ def splunk_ingest_data(request, splunk_hec_uri, sc4s, splunk_events_cleanup):
     ):
         addon_path = request.config.getoption("splunk_app")
         config_path = request.config.getoption("splunk_data_generator")
+        run_requirement_test = request.config.getoption("requirement_test")
+        '''
+        Add boolean input config if we need requirement tests to be run eg: requirement_tests = True/False
+        run_requirement_test = request.config.getoption("splunk_requirement_test")
+        '''
 
+        logging.info("Value " + str(addon_path))
+        logging.info("Value " + str(run_requirement_test))
         ingest_meta_data = {
             "session_headers": splunk_hec_uri[0].headers,
             "splunk_hec_uri": splunk_hec_uri[1],
@@ -578,7 +593,7 @@ def splunk_ingest_data(request, splunk_hec_uri, sc4s, splunk_events_cleanup):
         thread_count = int(request.config.getoption("thread_count"))
         store_events = request.config.getoption("store_events")
         IngestorHelper.ingest_events(
-            ingest_meta_data, addon_path, config_path, thread_count, store_events
+            ingest_meta_data, addon_path, config_path, thread_count, store_events, run_requirement_test
         )
         sleep(50)
         if "PYTEST_XDIST_WORKER" in os.environ:

--- a/pytest_splunk_addon/standard_lib/event_ingestors/ingestor_helper.py
+++ b/pytest_splunk_addon/standard_lib/event_ingestors/ingestor_helper.py
@@ -71,8 +71,8 @@ class IngestorHelper(object):
         if run_requirement_test:
             requirement_event = RequirementEventIngestor(addon_path)
             events = requirement_event.get_events()
-            input_type = "default"
             LOGGER.info(events)
+            input_type = "default"
             event_ingestor = cls.get_event_ingestor(input_type, ingest_meta_data)
             event_ingestor.ingest(events, thread_count)
             LOGGER.info("Ingestion Done")

--- a/pytest_splunk_addon/standard_lib/event_ingestors/ingestor_helper.py
+++ b/pytest_splunk_addon/standard_lib/event_ingestors/ingestor_helper.py
@@ -48,20 +48,15 @@ class IngestorHelper(object):
         tokenized_events = store_sample.get("tokenized_events")
         ingestor_dict = dict()
         for event in tokenized_events:
-            LOGGER.info("This called")
             input_type = event.metadata.get("input_type")
             if input_type in ["modinput", "windows_input", "syslog_tcp", "syslog_udp"]:
-                LOGGER.info(str(input_type))
                 event.event = event.event.encode("utf-8").decode()
             else:
                 event.event = event.event.encode("utf-8")
-                LOGGER.info(str(input_type))
             if input_type in ingestor_dict:
                 ingestor_dict[input_type].append(event)
-                LOGGER.info(str(input_type))
             else:
                 ingestor_dict[input_type] = [event]
-                LOGGER.info(str(input_type))
         for input_type, events in ingestor_dict.items():
             LOGGER.debug(
                 "Received the following input type for HEC event: {}".format(input_type))

--- a/pytest_splunk_addon/standard_lib/event_ingestors/ingestor_helper.py
+++ b/pytest_splunk_addon/standard_lib/event_ingestors/ingestor_helper.py
@@ -7,7 +7,7 @@ from . import (
 import logging
 from ..sample_generation import SampleXdistGenerator
 LOGGER = logging.getLogger("pytest-splunk-addon")
-
+from .requirement_event_ingester import RequirementEventIngestor
 class IngestorHelper(object):
     """
     Module for helper methods for ingestors.
@@ -33,7 +33,7 @@ class IngestorHelper(object):
         return ingestor
 
     @classmethod
-    def ingest_events(cls, ingest_meta_data, addon_path, config_path, thread_count, store_events):
+    def ingest_events(cls, ingest_meta_data, addon_path, config_path, thread_count, store_events, run_requirement_test):
         """
         Events are ingested in the splunk.
         Args:
@@ -41,9 +41,9 @@ class IngestorHelper(object):
             addon_path: Path to Splunk app package.
             config_path: Path to pytest-splunk-addon-sample-generator.conf.
             bulk_event_ingestion(bool): Boolean param for bulk event ingestion.
-
+            run_requirement_test(bool) :Boolean to identify if we want to run the requirement tests
         """
-        sample_generator = SampleXdistGenerator(addon_path, config_path)
+        sample_generator = SampleXdistGenerator(addon_path, config_path, run_requirement_test)
         store_sample = sample_generator.get_samples(store_events)
         tokenized_events = store_sample.get("tokenized_events")
         ingestor_dict = dict()
@@ -62,3 +62,7 @@ class IngestorHelper(object):
                 "Received the following input type for HEC event: {}".format(input_type))
             event_ingestor = cls.get_event_ingestor(input_type, ingest_meta_data)
             event_ingestor.ingest(events, thread_count)
+
+        if run_requirement_test:
+            requirement_event = RequirementEventIngestor(addon_path)
+            requirement_event.get_events()

--- a/pytest_splunk_addon/standard_lib/event_ingestors/ingestor_helper.py
+++ b/pytest_splunk_addon/standard_lib/event_ingestors/ingestor_helper.py
@@ -48,15 +48,20 @@ class IngestorHelper(object):
         tokenized_events = store_sample.get("tokenized_events")
         ingestor_dict = dict()
         for event in tokenized_events:
+            LOGGER.info("This called")
             input_type = event.metadata.get("input_type")
             if input_type in ["modinput", "windows_input", "syslog_tcp", "syslog_udp"]:
+                LOGGER.info(str(input_type))
                 event.event = event.event.encode("utf-8").decode()
             else:
                 event.event = event.event.encode("utf-8")
+                LOGGER.info(str(input_type))
             if input_type in ingestor_dict:
                 ingestor_dict[input_type].append(event)
+                LOGGER.info(str(input_type))
             else:
                 ingestor_dict[input_type] = [event]
+                LOGGER.info(str(input_type))
         for input_type, events in ingestor_dict.items():
             LOGGER.debug(
                 "Received the following input type for HEC event: {}".format(input_type))
@@ -65,4 +70,9 @@ class IngestorHelper(object):
 
         if run_requirement_test:
             requirement_event = RequirementEventIngestor(addon_path)
-            requirement_event.get_events()
+            events = requirement_event.get_events()
+            input_type = "default"
+            LOGGER.info(events)
+            event_ingestor = cls.get_event_ingestor(input_type, ingest_meta_data)
+            event_ingestor.ingest(events, thread_count)
+            LOGGER.info("Ingestion Done")

--- a/pytest_splunk_addon/standard_lib/event_ingestors/requirement_event_ingester.py
+++ b/pytest_splunk_addon/standard_lib/event_ingestors/requirement_event_ingester.py
@@ -1,0 +1,50 @@
+# ******* Input - requirement_log file, Transforms.conf of the addon Function:  parse and extract events from
+# requirement files from path TA/requirement_files/abc.log Example
+# TA_broken/requirement_files/sample_requirement_file.log
+# Function:  Sourcetype the event before ingesting  to Splunk by using
+# transforms.conf regex in config [Metadata: Sourcetype]
+
+import requests
+import logging
+import os
+
+LOGGER = logging.getLogger("pytest-splunk-addon")
+
+
+class RequirementEventIngestor(object):
+
+    def __init__(self, app_path):
+        """
+        app_path to drill down to requirement file folder in package/tests/requirement_files/
+        """
+        self.app_path = app_path
+        pass
+
+    def extract_raw_events(self):
+        """
+        This function returns raw events in <raw> section of the requirement files
+        Iterate over all the requirement files and then send all the events to ingestor helper class
+        """
+        pass
+
+    def extract_sourcetype(self):
+        """
+        Using app path extract sourcetype of the events
+        From tranforms.conf [Metadata: Sourcetype] Regex
+        This only works for syslog apps with this section
+        """
+        pass
+
+    def get_events(self):
+        req_file_path = os.path.join(self.app_path, "requirement_files")
+        if os.path.isdir(req_file_path):
+            for file1 in os.listdir(req_file_path):
+                filename = os.path.join(req_file_path, file1)
+                if filename.endswith(".log"):
+                    LOGGER.info(filename)
+        """
+        Send Sourcetyped events to event ingestor
+        """
+        pass
+
+

--- a/tests/addons/TA_fiction/requirement_files/sample_requirement_file.log
+++ b/tests/addons/TA_fiction/requirement_files/sample_requirement_file.log
@@ -1,0 +1,91 @@
+<?xml version="1.0"?>
+<device>
+   <vendor>Juniper</vendor>
+   <product>JunOS</product>
+   <version id="16.2R1" />
+   <version id="17.1R1" />
+   <version id="17.2R1" />
+   <event code="" name="RT_FLOW_SESSION_CREATE" format="syslog">
+      <transport type="syslog" />
+      <source>
+         <jira id="ADDON-25170"/>
+         <comment>Got this event form Juniper document.</comment>
+      </source>
+      <raw>
+         <![CDATA[2020-02-13T05:24:02 sample.dvc RT_FLOW: RT_FLOW_SESSION_CREATE: session created 1.1.1.1/34667->10.0.0.1/5048 0x0 junos-http 1.1.1.2/34667->10.0.0.2/5048 0x0 sample_src_rule_type sample_src_rule_name sample_dst_rule_type sample_dest_rule_name 6 1660(global) SAMPLE-SERVER-ZONE DUMMY_ZONE 113256 user1(admin) gg-0/0/0.1 SNMP DUMMY_APP UNKNOWN]]>
+      </raw>
+      <cim>
+         <models>
+            <model>Network Traffic</model>
+         </models>
+         <cim_fields>
+            <field name="action" value="allowed"/>
+            <field name="dest" value="10.0.0.1"/>
+            <field name="dest_ip" value="10.0.0.1"/>
+            <field name="dest_port" value="5048"/>
+            <field name="dest_zone" value="DUMMY_ZONE"/>
+            <field name="dvc" value="sample.dvc"/>
+            <field name="rule" value="sample_src_rule_name sample_dest_rule_name 1660(global)"/>
+            <field name="session_id" value="113256"/>
+            <field name="src" value="1.1.1.1"/>
+            <field name="src_ip" value="1.1.1.1"/>
+            <field name="src_port" value="34667"/>
+            <field name="src_zone" value="SAMPLE-SERVER-ZONE"/>
+            <field name="src_interface" value="gg-0/0/0.1"/>
+            <field name="user" value="user1"/>
+            <field name="app" value="SNMP DUMMY_APP"/>
+            <field name="transport" value="tcp"/>
+            <field name="protocol" value="ip"/>
+            <field name="vendor_produc" value="Juniper SRX"/>
+         </cim_fields>
+         <missing_recommended_fields>
+            <field>bytes</field>
+            <field>bytes_in</field>
+            <field>bytes_out</field>
+         </missing_recommended_fields>
+      </cim>
+      <test></test>
+   </event>
+   <event code="" name="RT_FLOW_SESSION_CREATE" format="syslog">
+      <transport type="syslog" />
+      <source>
+         <jira id="ADDON-25170"/>
+         <comment>Got this event form Juniper document.</comment>
+      </source>
+      <raw>
+         <![CDATA[2020-02-13T05:24:02 sample.dvc RT_FLOW: RT_FLOW_SESSION_CREATE: session created 1.1.1.1/34667->10.0.0.1/5048 0x0 junos-http 1.1.1.2/34667->10.0.0.2/5048 0x0 sample_src_rule_type sample_src_rule_name sample_dst_rule_type sample_dest_rule_name 6 1660(global) SAMPLE-SERVER-ZONE DUMMY_ZONE 113256 user1(admin) gg-0/0/0.1 SNMP DUMMY_APP UNKNOWN]]>
+      </raw>
+      <cim>
+         <models>
+            <model>Network Traffic</model>
+         </models>
+         <cim_fields>
+            <field name="action" value="allowed"/>
+            <field name="dest" value="10.0.0.1"/>
+            <field name="dest_ip" value="10.0.0.1"/>
+            <field name="dest_port" value="5048"/>
+            <field name="dest_zone" value="DUMMY_ZONE"/>
+            <field name="dvc" value="sample.dvc"/>
+            <field name="rule" value="sample_src_rule_name sample_dest_rule_name 1660(global)"/>
+            <field name="session_id" value="113256"/>
+            <field name="src" value="1.1.1.1"/>
+            <field name="src_ip" value="1.1.1.1"/>
+            <field name="src_port" value="34667"/>
+            <field name="src_zone" value="SAMPLE-SERVER-ZONE"/>
+            <field name="src_interface" value="gg-0/0/0.1"/>
+            <field name="user" value="user1"/>
+            <field name="app" value="SNMP DUMMY_APP"/>
+            <field name="transport" value="tcp"/>
+            <field name="protocol" value="ip"/>
+            <field name="vendor_produc" value="Juniper SRX"/>
+         </cim_fields>
+         <missing_recommended_fields>
+            <field>bytes</field>
+            <field>bytes_in</field>
+            <field>bytes_out</field>
+         </missing_recommended_fields>
+      </cim>
+      <test></test>
+   </event>
+</device>
+


### PR DESCRIPTION
Ingest requirement file events

- To enable requirement event ingestion use --requirement-test. 
- Sample requirement file is added to TA_fiction/requirement_file for testing.
- hec_raw_ingestor used to ingest raw requirement events to Splunk. 
- Requirement_event_ingester.py is added for parsing and extracting events from the log files. 
- Data is source typed using addons transforms.conf [Metadata: Sourcetype] for syslog sources.

Please review.