### PR TITLE
ACD-4565 Extractions for date and src fields causes failures in malware dm

### DIFF
--- a/pytest_splunk_addon/standard_lib/data_models/Malware.json
+++ b/pytest_splunk_addon/standard_lib/data_models/Malware.json
@@ -21,7 +21,7 @@
         },
         {
           "name": "date",
-          "type": "not_allowed_in_search",
+          "type": "optional",
           "comment": "The date of the malware event."
         },
         {
@@ -56,7 +56,7 @@
         },
         {
           "name": "src",
-          "type": "not_allowed_in_search",
+          "type": "optional",
           "comment": "The source of the event, such as a DAT file relay server. You can alias this from more specific fields, such as src_host, src_ip, or src_name."
         },
         {


### PR DESCRIPTION
* fix: Updated the Date and Src fields for Malware DM as per request. 