### PR TITLE
ci: updating matrix to execute tests on splunk 8.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,12 @@ workflows:
   build:
     jobs:
       - splunk-app-test/test_aio:
+          name: test-splunk-8-1
+          splunk_version: "8.1"
+          filters:
+            branches:
+              only: /.*/
+      - splunk-app-test/test_aio:
           name: test-splunk-8-0
           splunk_version: "8.0"
           filters:

--- a/.github/workflows/test_matrix.yml
+++ b/.github/workflows/test_matrix.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.7]
-        splunk-version: [7.2, 7.3, 8.0]
+        splunk-version: [7.2, 7.3, 8.0, 8.1]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
- Added 8.1 Splunk version in plugin's test matrix