### PR TITLE
[model:Dataset] format support in requirement test

### DIFF
--- a/pytest_splunk_addon/standard_lib/requirement_tests/test_generator.py
+++ b/pytest_splunk_addon/standard_lib/requirement_tests/test_generator.py
@@ -92,16 +92,20 @@ class ReqsTestGenerator(object):
                                 continue
                             for model in model_list:
                                 model = model.replace(" ", "_")
+                                # Function to extract data set
+                                model, dataset, subdataset = self.split_model(model)
+                                logging.info(dataset)
                                 req_test_id = req_test_id + 1
                                 yield pytest.param(
                                     {
                                         "model": model,
+                                        "dataset": dataset,
                                         "escaped_event": escaped_event,
                                         "filename": filename,
                                         "sourcetype": sourcetype,
                                         "Key_value_dict": key_value_dict,
                                     },
-                                    id=f"{model}::{filename}::req_test_id::{req_test_id}",
+                                    id=f"{model}::{dataset}::{filename}::req_test_id::{req_test_id}",
                                 )
                     except Exception:
                         req_test_id = req_test_id + 1
@@ -125,6 +129,29 @@ class ReqsTestGenerator(object):
         for model in root.iter('model'):
             model_list.append(str(model.text))
         return model_list
+
+    def split_model(self, model):
+        """
+        Input: Root of the xml file
+        Function to return list of models in each event of the log file
+        """
+        model_name = model.split(':', 2)
+        if len(model_name) == 3:
+            model = model_name[0]
+            dataset = model_name[1]
+            subdataset = model_name[2]
+        elif len(model_name) == 2:
+            model = model_name[0]
+            dataset = model_name[1]
+            subdataset = ""
+        else:
+            model = model_name[0]
+            dataset = ""
+            subdataset = ""
+        if model:
+            model = model.replace(" ", "_")
+        return model, dataset, subdataset
+
 
     def get_event(self, root):
         """

--- a/pytest_splunk_addon/standard_lib/requirement_tests/test_templates.py
+++ b/pytest_splunk_addon/standard_lib/requirement_tests/test_templates.py
@@ -32,13 +32,14 @@ class ReqsTestTemplates(object):
         for key, value in keyValueXML.items():
             res = key in keyValueprocessedSPL and value == keyValueprocessedSPL[key]
             if not res:
-                self.logger.info(key + " not in SPL extracted fields")
+                self.logger.info(key + "="+ value + " pair in requirement file not in SPL extracted fields values")
                 flag = False
         return flag
 
     @pytest.mark.splunk_searchtime_requirements
     def test_requirement_params(self, splunk_searchtime_requirement_param, splunk_search_util):
         model = splunk_searchtime_requirement_param["model"]
+        dataset = splunk_searchtime_requirement_param["dataset"]
         escaped_event = splunk_searchtime_requirement_param["escaped_event"]
         filename = splunk_searchtime_requirement_param["filename"]
         sourcetype = splunk_searchtime_requirement_param["sourcetype"]
@@ -56,7 +57,7 @@ class ReqsTestTemplates(object):
             assert result
 
         # Search for getting both data model and field extractions
-        search = f"| datamodel {model}  search | search source=	pytest_splunk_addon:hec:raw sourcetype={sourcetype} {escaped_event}"
+        search = f"| datamodel {model} {dataset}  search | search source=	pytest_splunk_addon:hec:raw sourcetype={sourcetype} {escaped_event}"
         datamodel_check = splunk_search_util.checkQueryCountIsGreaterThanZero(
             search, interval=INTERVAL, retries=RETRIES
         )


### PR DESCRIPTION
Minor update: If the model tag in the requirement file is of format Data_model:Dataset:sub_dataset. 
Requirement test will extract dataset and run the search with dataset.