### PR TITLE
INFRA-31687: Updating expected internal errors to suppress internal error failure

### DIFF
--- a/pytest_splunk_addon/.ignore_splunk_internal_errors
+++ b/pytest_splunk_addon/.ignore_splunk_internal_errors
@@ -1,1 +1,2 @@
 message_key="INPUT_CSV:INVALID_LOOKUP_TABLE_TYPE" message=The lookup table 'dmc_assets' requires a .csv or KV store lookup definition.
+message_key="" message=DAG Execution Exception: Search has been cancelled


### PR DESCRIPTION
Updated ignore_splunk_internal_error to suppress internal error failure.
Reference : https://jira.splunk.com/browse/INFRA-31687