### PR TITLE
feat: Req_test for syslog sources with event ingestion via SC4S

### DIFF
--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -72,6 +72,7 @@ services:
       - SPLUNK_PASSWORD=${SPLUNK_PASSWORD}
       - SPLUNK_HEC_TOKEN=${SPLUNK_HEC_TOKEN}
       - SPLUNK_START_ARGS=--accept-license
+      - TEST_SC4S_ACTIVATE_EXAMPLES=yes
 volumes:
   results:
     external: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       - SPLUNK_PASSWORD=${SPLUNK_PASSWORD}
       - SPLUNK_START_ARGS=--accept-license
       - SPLUNK_HEC_TOKEN=${SPLUNK_HEC_TOKEN}
+      - TEST_SC4S_ACTIVATE_EXAMPLES=yes
 
   uf:
     build:

--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -247,9 +247,10 @@ def pytest_addoption(parser):
     )
     group.addoption(
         "--requirement-test",
-        action="store_true",
+        action="store",
         dest="requirement_test",
-        help=("Default false use if requirement tests need to be run"),
+        default="None",
+        help="Default None, path to --requirement-test files if requirement tests need to be run",
     )
     group.addoption(
         "--splunk-uf-host",

--- a/pytest_splunk_addon/standard_lib/app_test_generator.py
+++ b/pytest_splunk_addon/standard_lib/app_test_generator.py
@@ -18,10 +18,10 @@ class AppTestGenerator(object):
     """
     Test Generator for an App.
     Generates test cases of Fields and CIM.
-    The test generator is to include all the specific test generators. 
+    The test generator is to include all the specific test generators.
 
-    AppTestGenerator should not have any direct generation methods, it should call a specific 
-    test generator methods only. Make sure there is no heavy initialization in __init__, all the 
+    AppTestGenerator should not have any direct generation methods, it should call a specific
+    test generator methods only. Make sure there is no heavy initialization in __init__, all the
     configurations and operations should only take place in generate_tests method.
 
     Args:
@@ -53,13 +53,13 @@ class AppTestGenerator(object):
             "Initializing ReqsTestGenerator to generate the test cases"
         )
         self.requirement_test_generator = ReqsTestGenerator(
-            self.pytest_config.getoption("splunk_app"),
+            self.pytest_config.getoption("requirement_test"),
         )
         self.indextime_test_generator = IndexTimeTestGenerator()
 
     def generate_tests(self, fixture):
         """
-        Generate the test cases based on the fixture provided 
+        Generate the test cases based on the fixture provided
         supported fixtures:
 
         * splunk_app_searchtime_*
@@ -68,7 +68,7 @@ class AppTestGenerator(object):
 
         Args:
             fixture(str): fixture name
-        """ 
+        """
         store_events = self.pytest_config.getoption("store_events")
         if fixture.startswith("splunk_searchtime_fields"):
             yield from self.dedup_tests(
@@ -79,7 +79,7 @@ class AppTestGenerator(object):
                 self.cim_test_generator.generate_tests(fixture), fixture
             )
         elif fixture.startswith("splunk_searchtime_requirement"):
-            if self.pytest_config.getoption("requirement_test"):
+            if self.pytest_config.getoption("requirement_test") != "None":
                 yield from self.dedup_tests(
                     self.requirement_test_generator.generate_tests(fixture), fixture
                 )

--- a/pytest_splunk_addon/standard_lib/event_ingestors/ingestor_helper.py
+++ b/pytest_splunk_addon/standard_lib/event_ingestors/ingestor_helper.py
@@ -45,7 +45,7 @@ class IngestorHelper(object):
             bulk_event_ingestion(bool): Boolean param for bulk event ingestion.
             run_requirement_test(bool) :Boolean to identify if we want to run the requirement tests
         """
-        sample_generator = SampleXdistGenerator(addon_path, config_path, run_requirement_test)
+        sample_generator = SampleXdistGenerator(addon_path, config_path)
         store_sample = sample_generator.get_samples(store_events)
         tokenized_events = store_sample.get("tokenized_events")
         ingestor_dict = dict()
@@ -65,11 +65,10 @@ class IngestorHelper(object):
             event_ingestor = cls.get_event_ingestor(input_type, ingest_meta_data)
             event_ingestor.ingest(events, thread_count)
 
-        if run_requirement_test:
-            requirement_event = RequirementEventIngestor(addon_path)
+        if run_requirement_test != "None":
+            requirement_event = RequirementEventIngestor(run_requirement_test)
             events = requirement_event.get_events()
-            LOGGER.info(events)
-            input_type = "default"
+            input_type = "syslog_tcp"
             event_ingestor = cls.get_event_ingestor(input_type, ingest_meta_data)
             event_ingestor.ingest(events, thread_count)
             LOGGER.info("Ingestion Done")

--- a/pytest_splunk_addon/standard_lib/requirement_tests/test_generator.py
+++ b/pytest_splunk_addon/standard_lib/requirement_tests/test_generator.py
@@ -4,7 +4,6 @@ Generates test cases to verify the event analytics logs.
 import pytest
 import logging
 import os
-import configparser
 from xml.etree import cElementTree as ET
 import re
 
@@ -35,10 +34,9 @@ class ReqsTestGenerator(object):
     """
     logger = logging.getLogger()
 
-    def __init__(self, app_path):
+    def __init__(self, requirement_files_path):
         logging.info("initializing ReqsTestGenerator class")
-        self.package_path = app_path
-        self.folder_path = os.path.join(str(self.package_path), "requirement_files")
+        self.folder_path = requirement_files_path
 
     def generate_tests(self, fixture):
         """
@@ -60,6 +58,32 @@ class ReqsTestGenerator(object):
         # self.logger.info(key_value_dict)
         return key_value_dict
 
+    def extract_transport_tag(self, event):
+        for transport in event.iter('transport'):
+            return str(transport.get('type'))
+
+    def strip_syslog_header(self, raw_event):
+        # remove leading space chars
+        raw_event = raw_event.strip()
+        CEF_format_match = re.search(r"\s(CEF:\d\|[^\|]+\|([^\|]+)\|[^\|]+\|[^\|]+\|[^\|]+\|([^\|]+)\|(.*))", raw_event)
+        if CEF_format_match:
+            stripped_header = CEF_format_match.group(1)
+            return stripped_header
+        regex_rfc5424 = re.search(
+            r"(?:(\d{4}[-]\d{2}[-]\d{2}[T]\d{2}[:]\d{2}[:]\d{2}(?:\.\d{1,6})?(?:[+-]\d{2}[:]\d{2}|Z)?)|-)\s(?:([\w][\w\d\.@-]*)|-)\s(.*)$",
+            raw_event)
+        if regex_rfc5424:
+            stripped_header = regex_rfc5424.group(3)
+            return stripped_header
+        regex_rfc3164 = re.search(
+            r"([A-Z][a-z][a-z]\s{1,2}\d{1,2}\s\d{2}[:]\d{2}[:]\d{2})\s+([\w][\w\d\.@-]*)\s(.*)$",
+            raw_event)
+        if regex_rfc3164:
+            stripped_header = regex_rfc3164.group(3)
+            return stripped_header
+        if not (CEF_format_match and regex_rfc3164 and regex_rfc5424):
+            return None
+
     def generate_cim_req_params(self):
         """
         Generate & Yield pytest.param for each test case.
@@ -67,61 +91,54 @@ class ReqsTestGenerator(object):
         """
         req_file_path = self.folder_path
         req_test_id = 0
-        src_regex = self.extractRegexTransforms()
-        #req_file_path = os.path.join(str(req_file_path))
         if os.path.isdir(req_file_path):
             for file1 in os.listdir(req_file_path):
                 filename = os.path.join(req_file_path, file1)
                 LOGGER.info(filename)
                 if filename.endswith(".log"):
                     try:
-                        model_list = None
-                        list_model_dataset_subdataset = None
-                        key_value_dict = {"None": "None"}
-                        escaped_event = None
-                        sourcetype = None
-                        abc = self.check_xml_format(filename)
-                        root = self.get_root(filename)
-                        for event_tag in root.iter('event'):
-                            unescaped_event = self.get_event(event_tag)
-                            sourcetype = self.extractSourcetype(src_regex, unescaped_event)
-                            escaped_event = self.escape_char_event(unescaped_event)
-                            model_list = self.get_models(event_tag)
-                            # Fetching kay value pair from XML
-                            key_value_dict = self.extract_key_value_xml(event_tag)
-                            # self.logger.info(key_value_dict)
-                            if len(model_list) == 0:
-                                continue
-                            list_model_dataset_subdataset = []
-                            for model in model_list:
-                                model = model.replace(" ", "_")
-                                # Function to extract data set
-                                model_name = self.split_model(model)
-                                list_model_dataset_subdataset.append(model_name)
-                                logging.info(model_name)
-                            req_test_id = req_test_id + 1
-                            yield pytest.param(
-                                {
-                                    "model_list": list_model_dataset_subdataset,
-                                    "escaped_event": escaped_event,
-                                    "filename": filename,
-                                    "sourcetype": sourcetype,
-                                    "Key_value_dict": key_value_dict,
-                                },
-                                id=f"{model_list}::{filename}::req_test_id::{req_test_id}",
-                            )
+                        self.check_xml_format(filename)
                     except Exception:
+                        LOGGER.error("Invalid XML")
+                        continue
+                    root = self.get_root(filename)
+                    event_no = 0
+                    for event_tag in root.iter('event'):
+                        event_no += 1
+                        unescaped_event = self.get_event(event_tag)
+                        transport_type = self.extract_transport_tag(event_tag)
+                        if transport_type == "syslog":
+                            stripped_event = self.strip_syslog_header(unescaped_event)
+                        else:
+                            # todo: non syslog events are skipped currently until we support it
+                            continue
+                        if stripped_event is None:
+                            LOGGER.error("Syslog event do not match CEF, RFC_3164, RFC_5424 format")
+                            continue
+                        escaped_event = self.escape_char_event(stripped_event)
+                        model_list = self.get_models(event_tag)
+                        # Fetching kay value pair from XML
+                        key_value_dict = self.extract_key_value_xml(event_tag)
+                        # self.logger.info(key_value_dict)
+                        if len(model_list) == 0:
+                            LOGGER.info("No model in this event")
+                            continue
+                        list_model_dataset_subdataset = []
+                        for model in model_list:
+                            model = model.replace(" ", "_")
+                            # Function to extract data set
+                            model_name = self.split_model(model)
+                            list_model_dataset_subdataset.append(model_name)
+                            logging.info(model_name)
                         req_test_id = req_test_id + 1
                         yield pytest.param(
                             {
                                 "model_list": list_model_dataset_subdataset,
                                 "escaped_event": escaped_event,
-                                "filename": filename,
-                                "sourcetype": sourcetype,
+                                "Key_value_dict": key_value_dict,
                             },
-                            id=f"{model_list}::{filename}::req_test_id::{req_test_id}",
+                            id=f"{model_list}::{filename}::event_no::{event_no}::req_test_id::{req_test_id}",
                         )
-
 
     def get_models(self, root):
         """
@@ -177,8 +194,10 @@ class ReqsTestGenerator(object):
         return root
 
     def check_xml_format(self, file_name):
-        if (ET.parse(file_name)):
+        if ET.parse(file_name):
             return True
+        else:
+            return False
 
     def escape_char_event(self, event):
         """
@@ -192,38 +211,3 @@ class ReqsTestGenerator(object):
         for character in escape_splunk_chars:
             event = event.replace(character, '\\' + character)
         return event
-
-    def extractRegexTransforms(self):
-        """
-        Requirement : app transform.conf
-        Return: SrcRegex objects list containing pair of regex and sourcetype
-        """
-        parser = configparser.ConfigParser(interpolation=None)
-        transforms_path = os.path.join(str(self.package_path), "default/transforms.conf")
-        parser.read_file(open(transforms_path))
-        list_src_regex = []
-        for stanza in parser.sections():
-            stanza_keys = list(parser[stanza].keys())
-            obj = SrcRegex()
-            if "dest_key" in stanza_keys:
-                if str(parser[stanza]["dest_key"]) == "MetaData:Sourcetype":
-                    for key in stanza_keys:
-                        key_value = str(parser[stanza][key])
-                        if key == "regex":
-                            obj.regex_src = key_value
-                        if key == "format":
-                            obj.source_type = key_value
-                    list_src_regex.append(obj)
-        return list_src_regex
-
-    def extractSourcetype(self, list_src_regex, event):
-        """
-        Input: event, List of SrcRegex
-        Return:Sourcetype of the event
-        """
-        sourcetype = None
-        for regex_src_obj in list_src_regex:
-            regex_match = re.search(regex_src_obj.regex_src, event)
-            if regex_match:
-                _, sourcetype = str(regex_src_obj.source_type).split('::', 1)
-        return sourcetype

--- a/tests/requirement_test/sample_requirement.log
+++ b/tests/requirement_test/sample_requirement.log
@@ -12,7 +12,7 @@
          <comment>Got this event form Juniper document.</comment>
       </source>
       <raw>
-         <![CDATA[2020-02-13T05:24:02 sample.dvc RT_FLOW: RT_FLOW_SESSION_CREATE: session created 1.1.1.1/34667->10.0.0.1/5048 0x0 junos-http 1.1.1.2/34667->10.0.0.2/5048 0x0 sample_src_rule_type sample_src_rule_name sample_dst_rule_type sample_dest_rule_name 6 1660(global) SAMPLE-SERVER-ZONE DUMMY_ZONE 113256 user1(admin) gg-0/0/0.1 SNMP DUMMY_APP UNKNOWN]]>
+         <![CDATA[<111> 2020-02-12T03:27:09+10:00 sample.dvc RT_FLOW: RT_FLOW_SESSION_CREATE: session created 1.1.1.1/34667->10.0.0.1/5048 0x0 junos-http 1.1.1.2/34667->10.0.0.2/5048 0x0 sample_src_rule_type sample_src_rule_name sample_dst_rule_type sample_dest_rule_name 6 1660(global) SAMPLE-SERVER-ZONE DUMMY_ZONE 113256 user1(admin) gg-0/0/0.1 SNMP DUMMY_APP UNKNOWN]]>
       </raw>
       <cim>
          <models>
@@ -36,7 +36,7 @@
             <field name="app" value="SNMP DUMMY_APP"/>
             <field name="transport" value="tcp"/>
             <field name="protocol" value="ip"/>
-            <field name="vendor_produ" value="Juniper SRX"/>
+            <field name="vendor_product" value="Juniper SRX"/>
          </cim_fields>
          <missing_recommended_fields>
             <field>bytes</field>

--- a/tests/requirement_test/sample_requirement_failure.log
+++ b/tests/requirement_test/sample_requirement_failure.log
@@ -12,7 +12,7 @@
          <comment>Got this event form Juniper document.</comment>
       </source>
       <raw>
-         <![CDATA[2020-02-13T05:24:02 sample.dvc RT_FLOW: RT_FLOW_SESSION_CREATE: session created 1.1.1.1/34667->10.0.0.1/5048 0x0 junos-http 1.1.1.2/34667->10.0.0.2/5048 0x0 sample_src_rule_type sample_src_rule_name sample_dst_rule_type sample_dest_rule_name 6 1660(global) SAMPLE-SERVER-ZONE DUMMY_ZONE 113256 user1(admin) gg-0/0/0.1 SNMP DUMMY_APP UNKNOWN]]>
+         <![CDATA[<23> Nov 18 09:56:58  INTERNET-ROUTER RT_FLOW: RT_FLOW_SESSION_CREATE: session created 192.168.1.102/58662->8.8.8.8/53 junos-dns-udp 68.144.1.1/55893->8.8.8.8/53 TRUST-INET-ACCESS None 17 OUTBOUND-INTERNET-ACCESS TRUST INTERNET 6316 N/A(N/A) vlan.192]]>
       </raw>
       <cim>
          <models>
@@ -36,7 +36,7 @@
             <field name="app" value="SNMP DUMMY_APP"/>
             <field name="transport" value="tcp"/>
             <field name="protocol" value="ip"/>
-            <field name="vendor_product" value="Juniper SRX"/>
+            <field name="vendor_produ" value="Juniper SRX"/>
          </cim_fields>
          <missing_recommended_fields>
             <field>bytes</field>

--- a/tests/test_splunk_addon.py
+++ b/tests/test_splunk_addon.py
@@ -36,6 +36,11 @@ def setup_test_dir(testdir):
         os.path.join(testdir.tmpdir, ""),
     )
 
+    shutil.copytree(
+        os.path.join(testdir.request.config.invocation_dir, "tests/requirement_test"),
+        os.path.join(testdir.tmpdir, "tests/requirement_test"),
+    )
+
     shutil.copy(
         os.path.join(testdir.request.config.invocation_dir, "Dockerfile.splunk"),
         testdir.tmpdir,
@@ -493,7 +498,7 @@ def test_splunk_app_requirements(testdir):
         "--search-interval=4",
         "--search-retry=4",
         "--search-index=*,_internal",
-        "--requirement-test",
+        "--requirement-test=tests/requirement_test",
     )
     logger.info(result.outlines)
     logger.info(len(constants.TA_REQUIREMENTS_PASSED))

--- a/tests/unit/tests_standard_lib/test_app_test_generator.py
+++ b/tests/unit/tests_standard_lib/test_app_test_generator.py
@@ -10,7 +10,7 @@ config = {
     "splunk_dm_path": "fake_path",
     "store_events": True,
     "splunk_data_generator": "psa.conf",
-    "requirement_test": True,
+    "requirement_test": "fake_requirement_path",
 }
 pytest_config = namedtuple("Config", ["getoption"])
 test_config = pytest_config(getoption=lambda x, *y: config[x])
@@ -52,7 +52,7 @@ def test_app_test_generator_instantiation(
         config["splunk_app"], field_bank=config["field_bank"]
     )
     atg.cim_test_generator.assert_called_once_with(config["splunk_app"], path)
-    atg.requirement_test_generator.assert_called_once_with(config["splunk_app"])
+    atg.requirement_test_generator.assert_called_once_with(config["requirement_test"])
     atg.indextime_test_generator.assert_called_once_with()
 
 

--- a/tests/unit/tests_standard_lib/test_event_ingestors/test_ingestor_helper.py
+++ b/tests/unit/tests_standard_lib/test_event_ingestors/test_ingestor_helper.py
@@ -130,7 +130,7 @@ def test_events_can_be_ingested(
         config_path="tests/unit/event_ingestors",
         thread_count=20,
         store_events=False,
-        run_requirement_test=False,
+        run_requirement_test="None",
     )
     assert get_ingestor_mock.call_count == 2
     get_ingestor_mock.assert_has_calls(
@@ -151,9 +151,9 @@ def test_requirement_tests_can_be_run(
         config_path="tests/unit/event_ingestors",
         thread_count=20,
         store_events=False,
-        run_requirement_test=True,
+        run_requirement_test="fake_requirement_path",
     )
-    requirement_mock.assert_called_once_with("fake_path")
+    requirement_mock.assert_called_once_with("fake_requirement_path")
     requirement_mock.get_events.assert_called_once()
     assert get_ingestor_mock.ingest.call_count == 3
     get_ingestor_mock.ingest.assert_has_calls([call(requirement_events, 20)])

--- a/tests/unit/tests_standard_lib/test_event_ingestors/test_requirement_event_ingestor.py
+++ b/tests/unit/tests_standard_lib/test_event_ingestors/test_requirement_event_ingestor.py
@@ -3,13 +3,11 @@ from unittest.mock import MagicMock, call, patch
 from recordtype import recordtype
 from pytest_splunk_addon.standard_lib.event_ingestors.requirement_event_ingester import (
     RequirementEventIngestor,
-    SrcRegex,
     ET,
 )
 
 
 module = "pytest_splunk_addon.standard_lib.event_ingestors.requirement_event_ingester"
-src_regex = recordtype("SrcRegex", [("regex_src", None), ("source_type", None)])
 sample_event = recordtype(
     "SampleEvent",
     ["event", "metadata", "sample_name", ("key_fields", None), ("time_values", None)],
@@ -75,11 +73,14 @@ def configparser_mock(monkeypatch):
 @pytest.fixture()
 def requirement_ingestor_mocked(monkeypatch, mock_object):
     mock_object(
-        f"{module}.RequirementEventIngestor.extract_regex_transforms",
-        return_value=[src_regex("event", "host::$1")],
+        f"{module}.RequirementEventIngestor.check_xml_format", return_value=True
     )
     mock_object(
-        f"{module}.RequirementEventIngestor.check_xml_format", return_value=True
+        f"{module}.RequirementEventIngestor.get_models", return_value="Network_Traffic"
+    )
+    mock_object(
+        f"{module}.RequirementEventIngestor.extract_transport_tag",
+        return_value="syslog",
     )
     root_mock = mock_object(f"{module}.RequirementEventIngestor.get_root")
     root_mock.return_value = root_mock
@@ -88,17 +89,7 @@ def requirement_ingestor_mocked(monkeypatch, mock_object):
         f"{module}.RequirementEventIngestor.extract_raw_events",
         side_effect=lambda x: f"event: {x}",
     )
-    es_mock = mock_object(
-        f"{module}.RequirementEventIngestor.extract_sourcetype",
-        side_effect=("host$1", "host$2"),
-    )
-    return {"root_mock": root_mock, "ere_mock": ere_mock, "es_mock": es_mock}
-
-
-def test_src_regex_can_be_instantiated():
-    srcregex = SrcRegex()
-    assert hasattr(srcregex, "regex_src")
-    assert hasattr(srcregex, "source_type")
+    return {"root_mock": root_mock, "ere_mock": ere_mock}
 
 
 def test_check_xml_format():
@@ -118,30 +109,6 @@ def test_raw_events_can_be_extracted(root_mock):
     assert req.extract_raw_events(root_mock) == "raw event extracted"
 
 
-def test_regex_transforms_can_be_extracted(
-    open_mock, configparser_mock, src_regex_mock
-):
-    req = RequirementEventIngestor("fake_path")
-    assert req.extract_regex_transforms() == [
-        src_regex(None, 'comp::"$1"'),
-        src_regex("group=(?<extractone>[^,]+)", None),
-    ]
-
-
-def test_sourcetype_can_be_extracted():
-    req = RequirementEventIngestor("fake_path")
-    assert (
-        req.extract_sourcetype(
-            [
-                src_regex("alert", "source::host$1"),
-                src_regex("emergency", "source::host$2"),
-            ],
-            "event: alert something happened",
-        )
-        == "host$1"
-    )
-
-
 def test_events_can_be_obtained(
     mock_object, requirement_ingestor_mocked, sample_event_mock
 ):
@@ -151,22 +118,16 @@ def test_events_can_be_obtained(
     assert req.get_events() == [
         sample_event(
             event="event: session created",
-            metadata={"input_type": "default", "sourcetype": "host$1", "index": "main"},
+            metadata={"input_type": "syslog", "index": "main"},
             sample_name="requirement_test",
         ),
         sample_event(
             event="event: session closed",
-            metadata={"input_type": "default", "sourcetype": "host$2", "index": "main"},
+            metadata={"input_type": "syslog", "index": "main"},
             sample_name="requirement_test",
         ),
     ]
     requirement_ingestor_mocked["root_mock"].iter.assert_has_calls([call("event")])
     requirement_ingestor_mocked["ere_mock"].assert_has_calls(
         [call("session created"), call("session closed")]
-    )
-    requirement_ingestor_mocked["es_mock"].assert_has_calls(
-        [
-            call([src_regex("event", "host::$1")], "event: session created"),
-            call([src_regex("event", "host::$1")], "event: session closed"),
-        ]
     )

--- a/tests/unit/tests_standard_lib/test_requirement_tests/test_test_generator.py
+++ b/tests/unit/tests_standard_lib/test_requirement_tests/test_test_generator.py
@@ -1,14 +1,12 @@
 import pytest
+import traceback
 from unittest.mock import MagicMock, call, patch
 from collections import namedtuple
-from recordtype import recordtype
 from pytest_splunk_addon.standard_lib.requirement_tests.test_generator import (
     ReqsTestGenerator,
-    SrcRegex,
 )
 
 root_content = namedtuple("Element", ["text"])
-src_regex = recordtype("SrcRegex", [("regex_src", None), ("source_type", None)])
 
 
 @pytest.fixture()
@@ -39,49 +37,6 @@ def et_parse_mock(monkeypatch):
     return tree_mock
 
 
-@pytest.fixture()
-def src_regex_mock(monkeypatch):
-    monkeypatch.setattr(
-        "pytest_splunk_addon.standard_lib.requirement_tests.test_generator.SrcRegex",
-        src_regex,
-    )
-
-
-@pytest.fixture()
-def configparser_mock(monkeypatch):
-    config_mock = MagicMock()
-    config_mock.sections.return_value = [
-        "ta_fiction_lookup",
-        "fiction-rsc-delim-fields",
-        "fiction-tsc-regex",
-    ]
-    items = {
-        "ta_fiction_lookup": {"a": 1, "b": 3},
-        "fiction-rsc-delim-fields": {
-            "dest_key": "MetaData:Sourcetype",
-            "fields": "day_id, event_id, end_time, start_time",
-            "format": 'comp::"$1"',
-        },
-        "fiction-tsc-regex": {
-            "dest_key": "MetaData:Sourcetype",
-            "regex": "group=(?<extractone>[^,]+)",
-        },
-    }
-    config_mock.__getitem__.side_effect = lambda key: items[key]
-    config_mock.return_value = config_mock
-    monkeypatch.setattr(
-        "configparser.ConfigParser",
-        config_mock,
-    )
-    return config_mock
-
-
-def test_src_regex_can_be_instantiated():
-    srcregex = SrcRegex()
-    assert hasattr(srcregex, "regex_src")
-    assert hasattr(srcregex, "source_type")
-
-
 def test_generate_tests():
     with patch.object(
         ReqsTestGenerator,
@@ -108,11 +63,25 @@ def test_extract_key_value_xml():
     event.iter.assert_called_once_with("field")
 
 
+def test_extract_transport_tag():
+    event = MagicMock()
+    event.iter.side_effect = lambda x: (
+        d
+        for d in [
+            {"type": "syslog"},
+        ]
+    )
+    rtg = ReqsTestGenerator("fake_path")
+    out = rtg.extract_transport_tag(event)
+    assert out == "syslog"
+    event.iter.assert_called_once_with("transport")
+
+
 @pytest.mark.parametrize(
     "listdir_return_value, "
     "check_xml_format_return_value, "
+    "extract_transport_tag_return_value, "
     "root_events, "
-    "extractSourcetype_return_value, "
     "get_models_return_value, "
     "extract_key_value_xml_return_value, "
     "expected_output",
@@ -120,9 +89,9 @@ def test_extract_key_value_xml():
         (
             ["requirement.log"],
             [True],
-            {"event": ["event_1", "event_2"]},
-            ["splunkd", "sc4s"],
-            [["model_1:dataset_1", "model_2:dataset_2"], ["model_3:dataset_3"]],
+            ["syslog"],
+            {"event": ["<34>Oct 11 22:14:15 machine1 event_1"]},
+            [["model_1:dataset_1", "model_2:dataset_2"]],
             [{"field1": "value1", "field2": "value2"}, {"field3": "value3"}],
             [
                 (
@@ -132,59 +101,28 @@ def test_extract_key_value_xml():
                             ("model_2", "dataset_2", ""),
                         ],
                         "escaped_event": "event_1",
-                        "filename": "fake_path/requirement_files/requirement.log",
-                        "sourcetype": "splunkd",
                         "Key_value_dict": {"field1": "value1", "field2": "value2"},
                     },
                     "['model_1:dataset_1',"
-                    " 'model_2:dataset_2']::fake_path/requirement_files/requirement.log"
-                    "::req_test_id::1",
-                ),
-                (
-                    {
-                        "model_list": [("model_3", "dataset_3", "")],
-                        "escaped_event": "event_2",
-                        "filename": "fake_path/requirement_files/requirement.log",
-                        "sourcetype": "sc4s",
-                        "Key_value_dict": {"field3": "value3"},
-                    },
-                    "['model_3:dataset_3']::fake_path/requirement_files/requirement.log::req_test_id::2",
+                    " 'model_2:dataset_2']::fake_path/requirement.log"
+                    "::event_no::1::req_test_id::1",
                 ),
             ],
         ),
         (
             ["requirement.xml"],
             [True],
+            ["syslog"],
             {"event": ["event_1", "event_2"]},
-            ["splunkd", "sc4s"],
             [["model_1:dataset_1", "model_2:dataset_2"], ["model_3:dataset_3"]],
             [{"field1": "value1", "field2": "value2"}, {"field3": "value3"}],
             [],
         ),
         (
-            ["not_requirement.log"],
-            Exception,
-            {"event": ["event_1", "event_2"]},
-            ["splunkd", "sc4s"],
-            [["model_1:dataset_1", "model_2:dataset_2"], ["model_3:dataset_3"]],
-            [{"field1": "value1", "field2": "value2"}, {"field3": "value3"}],
-            [
-                (
-                    {
-                        "model_list": None,
-                        "escaped_event": None,
-                        "filename": "fake_path/requirement_files/not_requirement.log",
-                        "sourcetype": None,
-                    },
-                    "None::fake_path/requirement_files/not_requirement.log::req_test_id::1",
-                ),
-            ],
-        ),
-        (
             ["req.log"],
             [True],
+            ["syslog"],
             {"event": ["event_1"]},
-            ["splunkd", "sc4s"],
             [[]],
             [{"field1": "value1", "field2": "value2"}, {"field3": "value3"}],
             [],
@@ -196,8 +134,8 @@ def test_generate_cim_req_params(
     root_mock,
     listdir_return_value,
     check_xml_format_return_value,
+    extract_transport_tag_return_value,
     root_events,
-    extractSourcetype_return_value,
     get_models_return_value,
     extract_key_value_xml_return_value,
     expected_output,
@@ -208,21 +146,15 @@ def test_generate_cim_req_params(
     os_listdir_mock.return_value = listdir_return_value
     root_mock.tags.update(root_events)
     with patch.object(
-        ReqsTestGenerator,
-        "extractRegexTransforms",
-        retrun_value=[
-            src_regex(source_type='comp::"$1"', regex_src="group=(?<extractone>[^,]+)")
-        ],
-    ), patch.object(
         ReqsTestGenerator, "check_xml_format", side_effect=check_xml_format_return_value
+    ), patch.object(
+        ReqsTestGenerator,
+        "extract_transport_tag",
+        side_effect=extract_transport_tag_return_value,
     ), patch.object(
         ReqsTestGenerator, "get_root", side_effect=[root_mock]
     ), patch.object(
         ReqsTestGenerator, "get_event", side_effect=lambda x: x.text
-    ), patch.object(
-        ReqsTestGenerator,
-        "extractSourcetype",
-        side_effect=extractSourcetype_return_value,
     ), patch.object(
         ReqsTestGenerator, "escape_char_event", side_effect=lambda x: x
     ), patch.object(
@@ -270,7 +202,7 @@ def test_get_root(et_parse_mock):
     "is_xml_valid, expected_output",
     [
         (True, True),
-        (False, None),
+        (False, False),
     ],
 )
 def test_check_xml_format(et_parse_mock, is_xml_valid, expected_output):
@@ -322,21 +254,3 @@ def test_check_xml_format(et_parse_mock, is_xml_valid, expected_output):
 def test_escape_char_event(escape_char, expected_output):
     rtg = ReqsTestGenerator("fake_path")
     assert rtg.escape_char_event(f"SESSION {escape_char} CREATED") == expected_output
-
-
-def test_extrect_regex_transforms(open_mock, configparser_mock, src_regex_mock):
-    rtg = ReqsTestGenerator("fake_path")
-    out = rtg.extractRegexTransforms()
-    assert out == [
-        src_regex(source_type='comp::"$1"'),
-        src_regex(regex_src="group=(?<extractone>[^,]+)"),
-    ]
-
-
-def test_extract_sourcetype():
-    rtg = ReqsTestGenerator("fake_path")
-    out = rtg.extractSourcetype(
-        [src_regex(source_type='comp::"$1"', regex_src="group=(\\w+),")],
-        "event start group=alert, event end",
-    )
-    assert out == '"$1"'


### PR DESCRIPTION
Feature add:

- Requirement test event ingestion is done via SC4S.

- As logs are ingested via SC4S “extract_regex_transforms()” “extract_sourcetype()” functions are no longer needed to determine source type of event using transforms.conf
-  In the previous version the complete event was searched for via Splunk search but as now we use SC4S, the event ingested is processed and does not contain HEADER. Syslog Header is removed  from search by function strip_syslog_header()

- Change location of input requirement files from package/requirement_files -> tests/requirement_tests/  as package folder gets released and it cannot contain logs.

- Location of files and whether to run the requirement test or not will be given by the “requirement-test” parameter in pytest.ini file

	``—requirement-test=tests/requirement_files``



- extract_transport_tag() function added to determine the transport type of event and ingest data if it is syslog. 

``` <transport type="syslog" />```

- No ingestion for events that do not have a CIM tag

- Better error message(source_type, mismatched fields added for the event failure):
Sample error:
```E       AssertionError: Issue with the field extraction.
E         search=search index=* RT_UTM\: WEBFILTER_URL_BLOCKED\: WebFilter\: ACTION\="URL Blocked" 10.0.0.1\(1111\)\-\>10.0.0.2\(2222\) CATEGORY\="sample_category" RE\ASON\="dummy_reason" PROFILE\="dummy_profile" URL\=dummy_url OBJ\=dummy_obj username dummy_user roles dummy_user_roles |fields * 
E          Field_extraction_check: False 
E          Key value not extracted in splunk event: {'category': 'sample_category'} 
E          Mismatched key value: {'category': 'sample_category dummy_sub_category'}
E          source type of ingested event: juniper:junos:firewall 
E         
E       assert False
```

- Fixed unit test failures due to code change