### PR TITLE
Bug/windows input ingestion

### DIFF
--- a/pytest_splunk_addon/standard_lib/event_ingestors/requirement_event_ingester.py
+++ b/pytest_splunk_addon/standard_lib/event_ingestors/requirement_event_ingester.py
@@ -116,19 +116,27 @@ class RequirementEventIngestor(object):
                                     "hec_event",
                                 ):
                                     transport_type = "modinput"
-                                    LOGGER.info(
-                                        "sending data via HEC {}".format(filename)
-                                    )
                                     host, source, sourcetype = self.extract_params(
                                         event_tag
                                     )
                                     LOGGER.info(
-                                        f"sending data via HEC {host}, {source} {sourcetype}"
+                                        f"sending data transport_type:modinput filename:{filename} host:{host}, source:{source} sourcetype:{sourcetype}"
                                     )
                                 elif transport_type == "dbx":
                                     transport_type = "modinput"
+                                    host, source, sourcetype = self.extract_params(
+                                        event_tag
+                                    )
+                                    LOGGER.info(
+                                        f"sending data transport_type:dbx filename:{filename} host:{host}, source:{source} sourcetype:{sourcetype}"
+                                    )
                                 elif transport_type == "windows_input":
-                                    transport_type = "windows_input"
+                                    host, source, sourcetype = self.extract_params(
+                                        event_tag
+                                    )
+                                    LOGGER.info(
+                                        f"sending data transport_type:windows_input filename:{filename} host:{host}, source:{source} sourcetype:{sourcetype}"
+                                    )
                                 else:
                                     transport_type = "default"
                                 unescaped_event = self.extract_raw_events(event_tag)

--- a/pytest_splunk_addon/standard_lib/requirement_tests/requirement_test_datamodel_tag_constants.py
+++ b/pytest_splunk_addon/standard_lib/requirement_tests/requirement_test_datamodel_tag_constants.py
@@ -82,4 +82,5 @@ dict_datamodel_tag = {
     "Vulnerabilities": ["report", "vulnerability"],
     "Web": ["web"],
     "Web_Proxy": ["web", "proxy"],
+    "Data_Access":["data", "access"],
 }

--- a/pytest_splunk_addon/standard_lib/requirement_tests/test_generator.py
+++ b/pytest_splunk_addon/standard_lib/requirement_tests/test_generator.py
@@ -169,7 +169,7 @@ class ReqsTestGenerator(object):
                                 "modinput_params": modinput_params,
                                 "transport_type": transport_type,
                             },
-                            id=f"{model_list}::{filename}::event_no::{event_no}::req_test_id::{req_test_id}",
+                            id=f"{(' '.join(model_list))}::{filename}::event_no::{event_no}",
                         )
 
     def get_models(self, root):

--- a/tests/unit/tests_standard_lib/test_requirement_tests/test_test_generator.py
+++ b/tests/unit/tests_standard_lib/test_requirement_tests/test_test_generator.py
@@ -122,9 +122,8 @@ def test_extract_params():
                         "modinput_params": None,
                         "transport_type": "syslog",
                     },
-                    "['model_1:dataset_1',"
-                    " 'model_2:dataset_2']::fake_path/requirement.log"
-                    "::event_no::1::req_test_id::1",
+                    "model_1:dataset_1 "
+                    "model_2:dataset_2::fake_path/requirement.log::event_no::1",
                 ),
             ],
         ),


### PR DESCRIPTION
Please review -

- Fixed empty host source source type in ingested data in case of both windows_input and dbx
- Added Data model Data access in the requirement test dictionary 
- Fixed test name so that it can be added to .pytest.expect file to ignore expected failures [Tested this for failing event in a TA]

