### PR TITLE
fix: Ingestion failure where special char in host,source and sourcetype

### DIFF
--- a/pytest_splunk_addon/standard_lib/requirement_tests/test_templates.py
+++ b/pytest_splunk_addon/standard_lib/requirement_tests/test_templates.py
@@ -138,7 +138,7 @@ class ReqsTestTemplates(object):
             host = modinput_params["host"]
             source = modinput_params["source"]
             sourcetype = modinput_params["sourcetype"]
-            search = f"search index=* host={host} source={source} sourcetype={sourcetype} {escaped_event}|fields * "
+            search = f"search index=* host=\"{host}\" source=\"{source}\" sourcetype=\"{sourcetype}\" {escaped_event}|fields * "
         else:
             search = f"search index=* {escaped_event} |fields * "
         ingestion_check = splunk_search_util.checkQueryCountIsGreaterThanZero(

--- a/tests/requirement_test_modinput/sample_requirement_test_modinput.log
+++ b/tests/requirement_test_modinput/sample_requirement_test_modinput.log
@@ -5,7 +5,7 @@
   <version id="13.21" />
   <event code="" name="EventID_19_WmiEvent_(WmiEventFilter_activity_detected)_Change_All_Changes" format="">
     <version id="" />
-    <transport type="modinput" host="sample_host" source="XmlWinEventLog:Microsoft-Windows-Sysmon/Operational" sourcetype="xmlwineventlog"/>
+    <transport type="modinput" host="sample_host=test" source="XmlWinEventLog:Microsoft-Windows-Sysmon/Operational" sourcetype="xmlwineventlog"/>
     <source>
       <jira id="ADDON-35818 , ADDON-35825" />
       <comment />


### PR DESCRIPTION
Fix: JVM Ingestion failure where source contains "=" sign. If we add double qoutes around search string for host source sourcetype it resolves the issue.

Added a sample source with "=" sign to the test.