### PR TITLE
fix: Ingestion failure with quotes sign in host,source,sourcetype

### DIFF
--- a/pytest_splunk_addon/standard_lib/requirement_tests/test_generator.py
+++ b/pytest_splunk_addon/standard_lib/requirement_tests/test_generator.py
@@ -136,11 +136,15 @@ class ReqsTestGenerator(object):
                             "hec_event",
                         ):
                             host, source, sourcetype = self.extract_params(event_tag)
+                            host, source, sourcetype = self.escape_host_src_srctype(
+                                host, source, sourcetype
+                            )
                             modinput_params = {
                                 "host": host,
                                 "source": source,
                                 "sourcetype": sourcetype,
                             }
+
                         else:
                             # todo: non syslog/modinput events are skipped currently until we support it
                             continue
@@ -243,6 +247,12 @@ class ReqsTestGenerator(object):
                 source_type = transport.get("sourcetype")
         return host, source, source_type
 
+    def escape_host_src_srctype(self, host, source, sourcetype):
+        escaped_host = host.replace('"', '\\"')
+        escaped_source = source.replace('"', '\\"')
+        escaped_sourcetype = sourcetype.replace('"', '\\"')
+        return escaped_host, escaped_source, escaped_sourcetype
+
     def escape_char_event(self, event):
         """
         Input: Event getting parsed
@@ -259,7 +269,6 @@ class ReqsTestGenerator(object):
             "%",
             "^",
             "&",
-            "*",
             "(",
             ")",
             "-",

--- a/tests/requirement_test_modinput/sample_requirement_test_modinput.log
+++ b/tests/requirement_test_modinput/sample_requirement_test_modinput.log
@@ -5,7 +5,7 @@
   <version id="13.21" />
   <event code="" name="EventID_19_WmiEvent_(WmiEventFilter_activity_detected)_Change_All_Changes" format="">
     <version id="" />
-    <transport type="modinput" host="sample_host=test" source="XmlWinEventLog:Microsoft-Windows-Sysmon/Operational" sourcetype="xmlwineventlog"/>
+    <transport type="modinput" host="sample&quot;test&quot;_host=test" source="XmlWinEventLog:Microsoft-Windows-Sysmon/Operational" sourcetype="xmlwineventlog"/>
     <source>
       <jira id="ADDON-35818 , ADDON-35825" />
       <comment />


### PR DESCRIPTION
Fix ingestion failure due to * replaced by / 
Fix ingestion failure where host source sourcetype contains " sign. Added to &quot;test&quot; to test host value