### PR TITLE
feat:Exceptions support in requirement test

### DIFF
--- a/pytest_splunk_addon/standard_lib/requirement_tests/test_generator.py
+++ b/pytest_splunk_addon/standard_lib/requirement_tests/test_generator.py
@@ -49,13 +49,14 @@ class ReqsTestGenerator(object):
             yield from self.generate_cim_req_params()
 
     # Extract key values pair XML
-    def extract_key_value_xml(self, event):
+    def extract_key_value_xml(self, event, type):
         key_value_dict = keyValue()
-        for fields in event.iter("field"):
-            if fields.get("name"):
-                field_name = fields.get("name")
-                field_value = fields.get("value")
-                key_value_dict.add(field_name, field_value)
+        for type_fields in event.iter(type):
+            for fields in type_fields.iter("field"):
+                if fields.get("name"):
+                    field_name = fields.get("name")
+                    field_value = fields.get("value")
+                    key_value_dict.add(field_name, field_value)
         # self.logger.info(key_value_dict)
         return key_value_dict
 
@@ -152,8 +153,14 @@ class ReqsTestGenerator(object):
                         escaped_event = self.escape_char_event(unescaped_event)
                         model_list = self.get_models(event_tag)
                         # Fetching kay value pair from XML
-                        key_value_dict = self.extract_key_value_xml(event_tag)
-                        # self.logger.info(key_value_dict)
+                        key_value_dict = self.extract_key_value_xml(
+                            event_tag, "cim_fields"
+                        )
+                        exceptions_dict = self.extract_key_value_xml(
+                            event_tag, "exceptions"
+                        )
+                        self.logger.info(key_value_dict)
+                        self.logger.info(exceptions_dict)
                         if len(model_list) == 0:
                             LOGGER.info("No model in this event")
                             continue
@@ -172,6 +179,7 @@ class ReqsTestGenerator(object):
                                 "Key_value_dict": key_value_dict,
                                 "modinput_params": modinput_params,
                                 "transport_type": transport_type,
+                                "exceptions_dict": exceptions_dict,
                             },
                             id=f"{(' '.join(model_list))}::{filename}::event_no::{event_no}",
                         )

--- a/pytest_splunk_addon/standard_lib/requirement_tests/test_templates.py
+++ b/pytest_splunk_addon/standard_lib/requirement_tests/test_templates.py
@@ -28,13 +28,13 @@ class ReqsTestTemplates(object):
         return new_dict
 
     # Function to compare the fields extracted from XML and the fields extracted from Splunk search
-    def compare(self, keyValueSPL, keyValueXML):
+    def compare(self, keyValueSPL, keyValueXML, escapedKeyValue):
         dict_missing_key_value = {}
         keyValueprocessedSPL = self.process_str(keyValueSPL)
         flag = True
         for key, value in keyValueXML.items():
             res = key in keyValueprocessedSPL and value == keyValueprocessedSPL[key]
-            if not res:
+            if (not res) and (key not in escapedKeyValue):
                 dict_missing_key_value.update({key: value})
                 flag = False
         return flag, dict_missing_key_value
@@ -125,8 +125,10 @@ class ReqsTestTemplates(object):
         model_datalist = splunk_searchtime_requirement_param["model_list"]
         escaped_event = splunk_searchtime_requirement_param["escaped_event"]
         key_values_xml = splunk_searchtime_requirement_param["Key_value_dict"]
+        exceptions_dict = splunk_searchtime_requirement_param["exceptions_dict"]
         modinput_params = splunk_searchtime_requirement_param["modinput_params"]
         transport_type = splunk_searchtime_requirement_param["transport_type"]
+        logging.info(exceptions_dict)
         # search = f" search source= pytest_splunk_addon:hec:raw sourcetype={sourcetype} {escaped_event} |fields * "
         # removed source and sourcetype as sc4s assigns it based on event
         if transport_type in (
@@ -173,7 +175,7 @@ class ReqsTestTemplates(object):
         self.logger.info(f"Data model check: {datamodel_check}")
         sourcetype = keyValue_dict_SPL["_sourcetype"]
         field_extraction_check, missing_key_value = self.compare(
-            keyValue_dict_SPL, key_values_xml
+            keyValue_dict_SPL, key_values_xml, exceptions_dict
         )
         self.logger.info(f"Field mapping check: {field_extraction_check}")
         mismapped_key_value_pair = {}

--- a/tests/requirement_test/sample_requirement.log
+++ b/tests/requirement_test/sample_requirement.log
@@ -36,13 +36,16 @@
             <field name="app" value="SNMP DUMMY_APP"/>
             <field name="transport" value="tcp"/>
             <field name="protocol" value="ip"/>
-            <field name="vendor_product" value="Juniper SRX"/>
+            <field name="vendor_product" value="Incorrect vendor product"/>
          </cim_fields>
          <missing_recommended_fields>
             <field>bytes</field>
             <field>bytes_in</field>
             <field>bytes_out</field>
          </missing_recommended_fields>
+         <exceptions>
+            <field name="vendor_product" value="Incorrect vendor product" reason="testing exceptions"/>
+         </exceptions>
       </cim>
       <test></test>
    </event>

--- a/tests/unit/tests_standard_lib/test_requirement_tests/test_test_generator.py
+++ b/tests/unit/tests_standard_lib/test_requirement_tests/test_test_generator.py
@@ -50,17 +50,16 @@ def test_generate_tests():
 
 def test_extract_key_value_xml():
     event = MagicMock()
-    event.iter.side_effect = lambda x: (
-        d
-        for d in [
-            {"name": "field1", "value": "value1"},
-            {"name": "field2", "value": "value2"},
-        ]
-    )
-    rtg = ReqsTestGenerator("fake_path")
-    out = rtg.extract_key_value_xml(event)
-    assert out == {"field1": "value1", "field2": "value2"}
-    event.iter.assert_called_once_with("field")
+    with patch.object(
+        ReqsTestGenerator,
+        "extract_key_value_xml",
+        side_effect=[
+            {"field1": "value1", "field2": "value2"},
+        ],
+    ):
+        rtg = ReqsTestGenerator("fake_path")
+        out = rtg.extract_key_value_xml(event, "cim_fields")
+        assert out == {"field1": "value1", "field2": "value2"}
 
 
 def test_extract_transport_tag():
@@ -118,6 +117,7 @@ def test_extract_params():
                             ("model_2", "dataset_2", ""),
                         ],
                         "escaped_event": "event_1",
+                        "exceptions_dict": {"field3": "value3"},
                         "Key_value_dict": {"field1": "value1", "field2": "value2"},
                         "modinput_params": None,
                         "transport_type": "syslog",


### PR DESCRIPTION
Please review -

- Added support for exceptions tag in <CIM> section
- Added exception field for testing in sample_requirement.log with an incorrect value, Incorrect value here is not generating an error as field is in exception section(vendor_product)
- Unit tests updated 
    
```            
<field name="app" value="SNMP DUMMY_APP"/>
            <field name="transport" value="tcp"/>
            <field name="protocol" value="ip"/>
            <field name="vendor_product" value="Incorrect vendor product"/>
         </cim_fields>
         <missing_recommended_fields>
            <field>bytes</field>
            <field>bytes_in</field>
            <field>bytes_out</field>
         </missing_recommended_fields>
         <exceptions>
            <field name="vendor_product" value="Incorrect vendor product" reason="testing exceptions"/>
         </exceptions>
```
