### PR TITLE
ci: updated .releaserc to resolve release issue

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -43,7 +43,7 @@
             },
             {
               "files": ["pyproject.toml"],
-              "from": "version ?=.*",
+              "from": "version = \"[0-9]+.[0-9]+.[0-9]+\"",
               "to": "version = \"${nextRelease.version}\"",
               "results": [
                 {


### PR DESCRIPTION
* The semantic-release stage was breaking due to the regex of .releaserc, which was making 2 versions from pyproject.toml. So, updated regex to match adequate version.