### PR TITLE
chore: rollback version bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@
 
 [tool.poetry]
 name = "pytest-splunk-addon"
-version = "1.10.0"
+version = "1.9.6"
 description = "A Dynamic test tool for Splunk Apps and Add-ons"
 authors = ["rfaircloth-splunk <rfaircloth@splunk.com>"]
 license = "APACHE-2.0"

--- a/pytest_splunk_addon/__init__.py
+++ b/pytest_splunk_addon/__init__.py
@@ -18,4 +18,4 @@
 
 __author__ = """Splunk Inc."""
 __email__ = "rfaircloth@splunk.com"
-__version__ = "1.10.0"
+__version__ = "1.9.6"


### PR DESCRIPTION
This commit rollbacks the version update pushed by semantic-release-bot and should trigger a new release procedure, so we can actually release a new version of the PSA (both in Github and PyPi).