### PR TITLE
ci: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @edersonbrilhante @arys-splunk


### PR DESCRIPTION
Putting Ederson and myself as codeowners. I put myself as a backup, just not to have 1 person owning the whole PSA.