### PR TITLE
ci: apply concurrency for build-test-release job

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -10,6 +10,10 @@ on:
   pull_request:
     branches: [main, develop]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   compliance-dependencies:
     name: Compliance Dependencies


### PR DESCRIPTION
Inspired by https://github.com/pypa/pip/commit/fa2d428e436c26dc072744aadd4d5d58ea42b743

Docs: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency