### PR TITLE
feat!: Refactor Basic class for requirement test 

### DIFF
--- a/pytest_splunk_addon/standard_lib/addon_requirements_basic.py
+++ b/pytest_splunk_addon/standard_lib/addon_requirements_basic.py
@@ -1,5 +1,4 @@
-#
-# Copyright 2021 Splunk Inc.
+# Copyright 2022 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,30 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# -*- coding: utf-8 -*-
 """
-Base class for test cases. Provides test cases to verify
-field extractions and CIM compatibility.
+Base class for requirement test cases.
 """
-
-from .fields_tests import FieldTestTemplates
-from .cim_tests import CIMTestTemplates, FieldTestHelper
-from .index_tests import IndexTimeTestTemplate
+from .requirement_tests import ReqsTestTemplates
+from .cim_tests import FieldTestHelper
 import pytest
 
 
-class Basic(FieldTestTemplates, CIMTestTemplates, IndexTimeTestTemplate):
+class RequirementBasic(ReqsTestTemplates):
     """
-    Base class for test cases. Inherit this class to include the test
-    cases for an Add-on. Only implement the common tests here, all the other
-    specific test case should be implemented in a TestTemplate class and Basic
-    should inherit it.
+    Base class for requirement test cases.Only implement the common tests here.
     """
 
-    @pytest.mark.first
-    @pytest.mark.splunk_indextime
-    @pytest.mark.splunk_searchtime_cim
-    @pytest.mark.splunk_searchtime_fields
+    @pytest.mark.splunk_searchtime_requirements
     def test_events_with_untokenised_values(
         self, splunk_search_util, splunk_ingest_data, splunk_setup, record_property
     ):

--- a/pytest_splunk_addon/standard_lib/requirement_tests/test_templates.py
+++ b/pytest_splunk_addon/standard_lib/requirement_tests/test_templates.py
@@ -144,7 +144,10 @@ class ReqsTestTemplates(object):
 
     @pytest.mark.splunk_searchtime_requirements
     def test_requirement_params(
-        self, splunk_searchtime_requirement_param, splunk_search_util
+        self,
+        splunk_searchtime_requirement_param,
+        splunk_search_util,
+        splunk_ingest_data,
     ):
         model_datalist = splunk_searchtime_requirement_param["model_list"]
         escaped_event = splunk_searchtime_requirement_param["escaped_event"]

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -649,7 +649,6 @@ TA_FICTION_INDEXTIME_SKIPPED = [
     "*test_splunk_fiction_indextime.py::Test_App::test_tags*splunk_searchtime_fields_tags0* SKIPPED*",
     "*test_splunk_fiction_indextime.py::Test_App::test_eventtype*splunk_searchtime_fields_eventtypes0* SKIPPED*",
     "*test_splunk_fiction_indextime.py::Test_App::test_savedsearches*splunk_searchtime_fields_savedsearches0* SKIPPED*",
-    "*test_splunk_fiction_indextime.py::Test_App::test_requirement_params* SKIPPED*",
 ]
 """
 Define the TA_fiction_indextime_broken add-on passed test case list.
@@ -739,7 +738,6 @@ TA_FICTION_INDEXTIME_BROKEN_SKIPPED = [
     "*test_splunk_fiction_indextime_broken.py::Test_App::test_tags*splunk_searchtime_fields_tags0* SKIPPED*",
     "*test_splunk_fiction_indextime_broken.py::Test_App::test_eventtype*splunk_searchtime_fields_eventtypes0* SKIPPED*",
     "*test_splunk_fiction_indextime_broken.py::Test_App::test_savedsearches*splunk_searchtime_fields_savedsearches0* SKIPPED*",
-    "*test_splunk_fiction_indextime_broken.py::Test_App::test_requirement_params* SKIPPED*",
 ]
 """
 Define TA_requirement_tests passed test

--- a/tests/test_splunk_addon.py
+++ b/tests/test_splunk_addon.py
@@ -520,8 +520,8 @@ def test_splunk_app_requirements(testdir):
 
     testdir.makepyfile(
         """
-        from pytest_splunk_addon.standard_lib.addon_basic import Basic
-        class Test_App(Basic):
+        from pytest_splunk_addon.standard_lib.addon_requirements_basic import RequirementBasic
+        class Test_App(RequirementBasic):
             def empty_method():
                 pass
     """
@@ -563,8 +563,8 @@ def test_splunk_app_requirements_modinput(testdir):
 
     testdir.makepyfile(
         """
-        from pytest_splunk_addon.standard_lib.addon_basic import Basic
-        class Test_App(Basic):
+        from pytest_splunk_addon.standard_lib.addon_requirements_basic import RequirementBasic
+        class Test_App(RequirementBasic):
             def empty_method():
                 pass
     """
@@ -611,8 +611,8 @@ def test_splunk_app_requirements_uf(testdir):
 
     testdir.makepyfile(
         """
-        from pytest_splunk_addon.standard_lib.addon_basic import Basic
-        class Test_App(Basic):
+        from pytest_splunk_addon.standard_lib.addon_requirements_basic import RequirementBasic
+        class Test_App(RequirementBasic):
             def empty_method():
                 pass
     """
@@ -654,8 +654,8 @@ def test_splunk_app_requirements_scripted(testdir):
 
     testdir.makepyfile(
         """
-        from pytest_splunk_addon.standard_lib.addon_basic import Basic
-        class Test_App(Basic):
+        from pytest_splunk_addon.standard_lib.addon_requirements_basic import RequirementBasic
+        class Test_App(RequirementBasic):
             def empty_method():
                 pass
     """


### PR DESCRIPTION
Changes in the PR-
1. Separate addon_basic class for requirement test,  keeping the same test functionality we currently have.
2. Add splunk_ingest_data fixture to test_requirement_params arguments
2. For this change we will need to update requirement_test/test_addon.py to - 
```
 from pytest_splunk_addon.standard_lib.addon_requirements_basic import RequirementBasic
        class Test_App(RequirementBasic):
            def empty_method():
                pass
```