### PR TITLE
refactor: remove test_events_with_untokenised_values from RequirementBasic

### DIFF
--- a/pytest_splunk_addon/standard_lib/addon_requirements_basic.py
+++ b/pytest_splunk_addon/standard_lib/addon_requirements_basic.py
@@ -22,4 +22,5 @@ class RequirementBasic(ReqsTestTemplates):
     """
     Base class for requirement test cases. Only implement the common tests here.
     """
+
     pass

--- a/pytest_splunk_addon/standard_lib/addon_requirements_basic.py
+++ b/pytest_splunk_addon/standard_lib/addon_requirements_basic.py
@@ -16,50 +16,10 @@
 Base class for requirement test cases.
 """
 from .requirement_tests import ReqsTestTemplates
-from .cim_tests import FieldTestHelper
-import pytest
 
 
 class RequirementBasic(ReqsTestTemplates):
     """
-    Base class for requirement test cases.Only implement the common tests here.
+    Base class for requirement test cases. Only implement the common tests here.
     """
-
-    @pytest.mark.splunk_searchtime_requirements
-    def test_events_with_untokenised_values(
-        self, splunk_search_util, splunk_ingest_data, splunk_setup, record_property
-    ):
-        """
-        Test case to validate that all the events have been properly tokenised
-
-        Args:
-            splunk_search_util (SearchUtil): Object that helps to search on Splunk.
-            splunk_ingest_data (fixture): To ingest data into splunk.
-            record_property (fixture): Document facts of test cases.
-
-        """
-        query = f"search index=* ##*## | stats count by source, sourcetype"
-        record_property("Query", query)
-        results = list(
-            splunk_search_util.getFieldValuesList(
-                query,
-                interval=0,
-                retries=0,
-            )
-        )
-        if results:
-            record_property("results", results)
-            result_str = FieldTestHelper.get_table_output(
-                headers=["Source", "Sourcetype"],
-                value_list=[
-                    [
-                        result.get("source"),
-                        result.get("sourcetype"),
-                    ]
-                    for result in results
-                ],
-            )
-            assert False, (
-                f"For the query: '{query}'\n"
-                f"Some fields are not tokenized in the events of following source and sourcetype \n{result_str}"
-            )
+    pass

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -743,7 +743,6 @@ TA_FICTION_INDEXTIME_BROKEN_SKIPPED = [
 Define TA_requirement_tests passed test
 """
 TA_REQUIREMENTS_PASSED = [
-    "*test_splunk_app_requirements.py::Test_App::test_events_with_untokenised_values PASSED*",
     "*test_splunk_app_requirements.py::Test_App::test_requirement_params* PASSED*",
 ]
 
@@ -752,7 +751,6 @@ TA_REQUIREMENTS_FAILED = [
 ]
 
 TA_REQUIREMENTS_MODINPUT_PASSED = [
-    "*test_splunk_app_requirements_modinput.py::Test_App::test_events_with_untokenised_values PASSED*",
     "*test_splunk_app_requirements_modinput.py::Test_App::test_requirement_params* PASSED*",
 ]
 
@@ -761,7 +759,6 @@ TA_REQUIREMENTS_MODINPUT_FAILED = [
 ]
 
 TA_REQUIREMENTS_UF_PASSED = [
-    "*test_splunk_app_requirements_uf.py::Test_App::test_events_with_untokenised_values PASSED*",
     "*test_splunk_app_requirements_uf.py::Test_App::test_requirement_params* PASSED*",
 ]
 
@@ -770,7 +767,6 @@ TA_REQUIREMENTS_UF_FAILED = [
 ]
 
 TA_REQUIREMENTS_SCRIPTED_PASSED = [
-    "*test_splunk_app_requirements_scripted.py::Test_App::test_events_with_untokenised_values* PASSED*",
     "*test_splunk_app_requirements_scripted.py::Test_App::test_requirement_params* PASSED*",
 ]
 


### PR DESCRIPTION
There is no need to run test_events_with_untokenised_values test when running
requirement tests. It is needed when running knowledge tests.