### PR TITLE
ci: remove matrix option from test-splunk-matrix step

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -184,13 +184,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
         splunk-version: [8.1, 8.2]
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - name: Set up OS=${{ matrix.os }}::Python=3.7::Splunk=${{ matrix.splunk-version }}
+      - name: Set up OS=ubuntu-latest::Python=3.7::Splunk=${{ matrix.splunk-version }}
         uses: actions/setup-python@v1
         with:
           python-version: 3.7


### PR DESCRIPTION
While we are migrating to Kubernetes, I think it will be still valuable to remove bug in a pipeline not to waste Github's resources for no reason and maybe speed up our pipeline.