### PR TITLE
ci: make tests run in parallel

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -116,10 +116,57 @@ jobs:
       uses: reviewdog/action-misspell@v1.0.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-  
+
+  test-splunk-unit:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Install dependencies
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          poetry install
+          poetry run coverage run --source=./pytest_splunk_addon/standard_lib -m pytest -v tests/unit
+          poetry run coverage xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          directory: ./coverage/reports/
+          env_vars: OS,PYTHON
+          fail_ci_if_error: true
+          verbose: true
+
+  test-splunk-doc:
+    name: Test Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install and run tests
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          poetry install -E docker
+          poetry run pytest -v --splunk-version=${{ matrix.splunk-version }} -m doc
+
   test-splunk-external:
     runs-on: ubuntu-latest
     name: Test splunk external
+    needs:
+      - pre-commit
+      - compliance-dependencies
+      - compliance-copyrights
+      - test-splunk-doc
+      - test-splunk-unit
+      - review_secrets
+      - review-dog-misspell
     strategy:
       fail-fast: false
       matrix:
@@ -160,22 +207,6 @@ jobs:
           name: splunk ${{ matrix.splunk-version }} external test artifacts
           path: |
             test-results-${{ matrix.splunk-version }}
-  
-  test-splunk-doc:
-    name: Test Docs
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-      - uses: actions/setup-python@v1
-        with:
-          python-version: 3.7
-      - name: Install and run tests
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          poetry install -E docker
-          poetry run pytest -v --splunk-version=${{ matrix.splunk-version }} -m doc
 
   test-splunk-matrix:
     name: Test Matrix
@@ -183,7 +214,6 @@ jobs:
       - pre-commit
       - compliance-dependencies
       - compliance-copyrights
-      - test-splunk-external
       - test-splunk-doc
       - test-splunk-unit
       - review_secrets
@@ -216,31 +246,10 @@ jobs:
           poetry install -E docker
           poetry run pytest -v --splunk-version=${{ matrix.splunk-version }} -m docker -k ${{ matrix.test-name }}
 
-  test-splunk-unit:
-    name: Unit tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-      - name: Install dependencies
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          poetry install
-          poetry run coverage run --source=./pytest_splunk_addon/standard_lib -m pytest -v tests/unit
-          poetry run coverage xml
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-          directory: ./coverage/reports/
-          env_vars: OS,PYTHON
-          fail_ci_if_error: true
-          verbose: true
   publish:
     name: publish
     needs:
+      - test-splunk-external
       - test-splunk-matrix
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -266,15 +266,9 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.7"
-      - name: Install and build
+      - name: Install Poetry
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
-          poetry build
-      - uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: Package
-          path: dist/
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v2.5.4
         with:

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -243,6 +243,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.7"
+      - uses: actions/download-artifact@v2
+        with:
+          name: analysis-reports
+          path: /tmp/analysis-reports
+      - name: Update Notices
+        run: cp -f /tmp/analysis-reports/NOTICE_summary NOTICE
       - name: Install Poetry
         run: |
           curl -sSL https://install.python-poetry.org | python3 -

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -173,7 +173,6 @@ jobs:
           python-version: 3.7
       - name: Install and run tests
         run: |
-          sudo apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
           curl -sSL https://install.python-poetry.org | python3 -
           poetry install -E docker
           poetry run pytest -v --splunk-version=${{ matrix.splunk-version }} -m doc
@@ -213,7 +212,6 @@ jobs:
           python-version: 3.7
       - name: Install and run tests
         run: |
-          sudo apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
           curl -sSL https://install.python-poetry.org | python3 -
           poetry install -E docker
           poetry run pytest -v --splunk-version=${{ matrix.splunk-version }} -m docker -k ${{ matrix.test-name }}
@@ -227,7 +225,6 @@ jobs:
           submodules: true
       - name: Install dependencies
         run: |
-          sudo apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
           curl -sSL https://install.python-poetry.org | python3 -
           poetry install
           poetry run coverage run --source=./pytest_splunk_addon/standard_lib -m pytest -v tests/unit

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -70,30 +70,7 @@ jobs:
         uses: returntocorp/semgrep-action@v1
         with:
           publishToken: ${{ secrets.SEMGREP_PUBLISH_TOKEN }}
-  
-  snyk:
-    name: security-vuln-snyk
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-      - uses: snyk/actions/setup@master
-      - uses: actions/setup-go@v2.1.3
-        with:
-          go-version: "1.13"
-      - name: Snyk monitor
-        run: snyk test --sarif-file-output=snyk-scan_requirements.sarif --all-projects --print-deps --severity-threshold=high
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-      - uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: snyk-results
-          path: snyk-scan_requirements.sarif
-  
+
   review_secrets:
     name: security-detect-secrets
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -194,6 +194,15 @@ jobs:
       fail-fast: false
       matrix:
         splunk-version: [8.1, 8.2]
+        test-name: [
+          "test_splunk_connection_docker",
+          "test_splunk_app_fiction",
+          "test_splunk_app_broken",
+          "test_splunk_app_cim",
+          "test_splunk_fiction_indextime",
+          "test_splunk_setup_fixture",
+          "test_splunk_app_requirements"
+        ]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -207,7 +216,7 @@ jobs:
           sudo apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
           curl -sSL https://install.python-poetry.org | python3 -
           poetry install -E docker
-          poetry run pytest -v --splunk-version=${{ matrix.splunk-version }} -m docker
+          poetry run pytest -v --splunk-version=${{ matrix.splunk-version }} -m docker -k ${{ matrix.test-name }}
 
   test-splunk-unit:
     name: Unit tests


### PR DESCRIPTION
This PR runs tests based on `-k` parameter in the CI, so instead of waiting > 1 hour until tests are finished, now it is 30 minutes of waiting :)

This PR also removes `snyk` and reorganises the overall pipeline to execute things faster.