### PR TITLE
fix: put helmut's REST connector back into PSA

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -133,6 +133,17 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "httplib2"
+version = "0.20.4"
+description = "A comprehensive HTTP client library."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+pyparsing = {version = ">=2.4.2,<3.0.0 || >3.0.0,<3.0.1 || >3.0.1,<3.0.2 || >3.0.2,<3.0.3 || >3.0.3,<4", markers = "python_version > \"3.0\""}
+
+[[package]]
 name = "idna"
 version = "3.3"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -485,7 +496,7 @@ docker = ["lovely-pytest-docker"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "40ece2ed956fcbec60328315b3c9cb2794c73401bf2e76d249d1017080af7075"
+content-hash = "3f5898edbbdfe54a74bd54566bc5281e75352570fba9af19a0f8a00ac5f338ab"
 
 [metadata.files]
 addonfactory-splunk-conf-parser-lib = [
@@ -577,6 +588,10 @@ freezegun = [
 ]
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
+]
+httplib2 = [
+    {file = "httplib2-0.20.4-py3-none-any.whl", hash = "sha256:8b6a905cb1c79eefd03f8669fd993c36dc341f7c558f056cb5a33b5c2f458543"},
+    {file = "httplib2-0.20.4.tar.gz", hash = "sha256:58a98e45b4b1a48273073f905d2961666ecf0fbac4250ea5b47aef259eb5c585"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ lovely-pytest-docker = { version="^0", optional = true }
 junitparser = "^2.2.0"
 addonfactory-splunk-conf-parser-lib = "^0.3.3"
 defusedxml = "^0.7.1"
+httplib2 = "^0.20.4"
 
 [tool.poetry.extras]
 docker = ['lovely-pytest-docker']

--- a/pytest_splunk_addon/helmut/connector/rest.py
+++ b/pytest_splunk_addon/helmut/connector/rest.py
@@ -1,0 +1,529 @@
+#
+# Copyright 2021 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import json
+import logging
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as et
+from xml.dom.minidom import parseString
+
+import httplib2
+import six
+
+from pytest_splunk_addon.helmut.exceptions import AuthenticationError
+
+LOGGER = logging.getLogger("helmut")
+
+
+class RESTConnector:
+    """
+    This represents workaround to access REST thru HTTP client library httplib2
+
+    Associated with each object is a C{http} object from the httplib which in
+    turn contains connection info, namespace and auth.
+
+    When a connector is logged in a sessionkey is generated and will be kept
+    until the point that you logout or the server is restarted.
+
+    When Splunk is restarted the connector I{tries} to login again
+
+    @ivar _service: The underlying service, aka the http request object
+    @cvar HEADERS: The default headers to pass with http request. this will
+    get appended with the 'Authorization' key when sessionkey is used
+
+    """
+
+    HEADERS = {"content-type": "text/xml; charset=utf-8"}
+    METHODS = ["GET", "POST", "PUT", "DELETE"]
+    SUCCESS = {"GET": "200", "POST": "201", "DELETE": "200", "PUT": "200"}
+
+    DEFAULT_USERNAME = "admin"
+    DEFAULT_PASSWORD = "changeme"
+    DEFAULT_OWNER = "admin"
+    DEFAULT_APP = (
+        "search"  # defaulting it search app for the case when app is not passed.
+    )
+
+    def __init__(self, splunk, username=None, password=None, app=None, owner=None):
+        """
+        Creates a new REST connector.
+
+        The connector will logged in when created with default values
+
+        @param splunk: The Splunk instance
+        @type splunk: L{..splunk.Splunk}
+        @param username: The username to use. If None (default)
+                         L{Connector.DEFAULT_USERNAME} is used.
+        @type username: str
+        @param password: The password to use. If None (default)
+                         L{Connector.DEFAULT_PASSWORD} is used.
+        @type password: str
+        @param app: The app to use.This will construct namespace <ownerr>:<app>
+        @type app: str
+        @param app: The owner to use.This will construct namespace <ownerr>:<app>
+        @type app: str
+
+        """
+        self._splunk = splunk
+        self._username = username or self.DEFAULT_USERNAME
+        self._password = password or self.DEFAULT_PASSWORD
+        self._owner = owner or self.DEFAULT_OWNER
+        self._app = app or self.DEFAULT_APP
+        self._attempt_login_time = 0
+        self.uri_base = splunk.uri_base()
+        self._timeout = 60
+        self._debug_level = 0
+        self._disable_ssl_certificate = True
+        self._follow_redirects = False
+        httplib2.debuglevel = self._debug_level
+        self.sessionkey = None
+        self._service = httplib2.Http(
+            timeout=self._timeout,
+            disable_ssl_certificate_validation=self._disable_ssl_certificate,
+        )
+        self._service.follow_redirects = self._follow_redirects
+        self._service.add_credentials(self._username, self._password)
+
+        splunk.register_start_listener(self)
+
+    @property
+    def splunk(self):
+        """
+        The Splunk object associated with this connector.
+
+        @rtype: L{Splunk<..splunk.Splunk>}
+        """
+        return self._splunk
+
+    @property
+    def username(self):
+        """
+        The username for this connector.
+
+        @rtype: str
+        """
+        return self._username
+
+    @username.setter
+    def username(self, value):
+        """
+        Setter for the username property
+        """
+        self._username = value
+
+    @property
+    def password(self):
+        """
+        The password for this connector.
+
+        @rtype: str
+        """
+        return self._password
+
+    @password.setter
+    def password(self, value):
+        """
+        Setter for the password property
+        """
+        self._password = value
+
+    @property
+    def namespace(self):
+        """
+        The namespace for this RESTconnector.
+
+        Will be in the format /<owner>/<app>
+
+        @rtype: str
+        """
+        return "/" + str(self._owner) + "/" + str(self._app)
+
+    @property
+    def owner(self):
+        """
+        The owner for this connector.
+
+        @rtype: str
+        """
+        return self._owner
+
+    @property
+    def app(self):
+        """
+        The app for this connector.
+
+        @rtype: str
+        """
+        return self._app
+
+    def make_request(
+        self,
+        method,
+        uri,
+        body=None,
+        urlparam=None,
+        use_sessionkey=False,
+        log_response=True,
+    ):
+        """
+        Make a HTTP request to an endpoint
+
+        @type  method: string
+        @param method: HTTP valid methods: PUT, GET, POST, DELETE
+        @type  uri: string
+        @param uri: URI of the REST endpoint
+        @type  body: string or dictionary or a sequence of two-element tuples
+        @param body: the request body
+        @type  urlparam: string/ dictionary or a sequence of two-element tuples
+        @param urlparam: the URL parameters
+        @type  use_sessionkey: bool
+        @param use_sessionkey: toggle for using sessionkey or not
+        @type  log_response: bool
+        @param log_response: log the response to ..log or not
+
+        >>> conn.make_request('POST', '/services/receivers/simple',
+        urlparam={'host': 'foo'}, body="my event")
+
+        """
+        if body is None:
+            body = ""
+        if type(body) != str and type(body) != str:
+            body = urllib.parse.urlencode(body)
+        if urlparam is None:
+            urlparam = ""
+        if type(urlparam) != str:
+            urlparam = urllib.parse.urlencode(urlparam)
+        if urlparam != "":
+            url = f"{self.uri_base}{uri}?{urlparam}"
+        else:
+            url = f"{self.uri_base}{uri}"
+
+        if use_sessionkey:
+            self._service.clear_credentials()
+            self.update_headers("Authorization", "Splunk %s" % self.sessionkey)
+        else:
+            if not self._service.credentials.credentials:
+                self._service.add_credentials(self._username, self._password)
+            if "Authorization" in self.HEADERS:
+                self.HEADERS.pop("Authorization")
+        response, content = self._service.request(
+            url, method, body=body, headers=self.HEADERS
+        )
+
+        LOGGER.info(
+            "Request  => {r}".format(
+                r={
+                    "method": method,
+                    "url": url,
+                    "body": body,
+                    "auth": f"{self._username}:{self._password}",
+                    "header": self.HEADERS,
+                }
+            )
+        )
+        if log_response:
+            LOGGER.info(f"Response => {response}")
+            LOGGER.debug(f"Content  => {content}")
+
+        return response, content
+
+    def make_requestNS(
+        self,
+        method,
+        uri,
+        body=None,
+        urlparam=None,
+        use_sessionkey=False,
+        log_response=True,
+    ):
+
+        """
+        Wrapper on top of make_request. For uri, don't use any of /services
+        or /serviceNS,just pass the endpoint,it will read the namespace from
+        connector itself
+
+        @type  method: string
+        @param method: HTTP valid methods: PUT, GET, POST, DELETE
+        @type  uri: string
+        @param uri: URI of the REST endpoint
+        @type  body: string or dictionary or a sequence of two-element tuples
+        @param body: the request body
+        @type  urlparam: string/ dictionary or a sequence of two-element tuples
+        @param urlparam: the URL parameters
+        @type  use_sessionkey: bool
+        @param use_sessionkey: toggle for using sessionkey or not
+        @type  log_response: bool
+        @param log_response: log the response to ..log or not
+
+        >>> conn.make_requestNS('GET', 'data/outputs/tcp/default')
+
+        """
+        uri = "/servicesNS" + self.namespace + uri
+        response, content = self.make_request(
+            method,
+            uri,
+            body,
+            urlparam=urlparam,
+            use_sessionkey=use_sessionkey,
+            log_response=log_response,
+        )
+        return response, content
+
+    def parse_content_json(self, content):
+        """
+        Parses the content object (in json format) to python dict
+
+        @type content: json
+        @param content: content object from http request in json format
+        """
+
+        return json.loads(str(content))
+
+    @property
+    def _service_arguments(self):
+        """
+        The arguments to pass to the Service (httplib in this case).
+
+        If makes sure that they have default values if nothing is specified.
+
+        @rtype: dict
+        @return: default values for the httplib service
+
+        """
+        return {
+            "username": self._username,
+            "password": self._password,
+            "namespace": self.namespace,
+            "uri_base": self.splunk.uri_base(),
+        }
+
+    def _recreate_service(self):
+        """
+        Clones the current service with the same values.
+
+        It then tries to log the service in if the old one was logged in.
+        Called when Splunk starts
+        """
+        _was_logged_in = self._was_logged_in()
+        service = self._clone_existing_service()
+        self._service = service
+        self.uri_base = self._service_arguments["uri_base"]
+        if _was_logged_in:
+            try:
+                self.login()
+            except AuthenticationError as autherr:
+                LOGGER.warn(
+                    "RESTConnector for username:{username} password:{password}"
+                    " login failed when recreating service. error msg:{error}".format(
+                        username=self.username,
+                        password=self.password,
+                        error=autherr.message,
+                    )
+                )
+
+    def login(self):
+        """
+        Logs the connector in.
+
+        Just hits the auth endpoint and retreives and sets the sessionkey.
+
+        """
+        body = urllib.parse.urlencode(
+            {"username": self._username, "password": self._password}
+        )
+        url = "{}{}".format(self.uri_base, "/services/auth/login")
+        response, content = self._service.request(url, "POST", body=body)
+        self._attempt_login_time = time.time()
+        if response.status != 200:
+            msg = "Login failed... response status: {} content: {}".format(
+                response.status,
+                content,
+            )
+            LOGGER.warn(msg)
+            raise AuthenticationError(msg)
+
+        root = et.fromstring(six.ensure_text(content, "utf-8"))
+        self.sessionkey = root[0].text
+        if not self._service.credentials.credentials:
+            self._service.add_credentials(self._username, self._password)
+
+    def _clone_existing_service(self):
+        """
+        clones the existing service
+
+        @return: The newly created service (httplib) http object
+        @rtype: http object
+        """
+        http = httplib2.Http(
+            timeout=self._timeout,
+            disable_ssl_certificate_validation=self._disable_ssl_certificate,
+        )
+        http.follow_redirects = False
+        http.add_credentials(
+            self._service_arguments["username"], self._service_arguments["password"]
+        )
+        return http
+
+    def logout(self):
+        """
+        Logs the connector out
+
+        This just unsets the sessionkey.
+
+        """
+        if "Authorization" in self.HEADERS:
+            self.HEADERS.pop("Authorization")
+        self.sessionkey = None
+        self._service.clear_credentials()
+
+    def is_logged_in(self):
+        """
+        Checks if the connector is logged in.
+
+        This checks if the sessionkey is set and is not expired.
+        @return: True if the connector is logged in
+        @rtype: bool
+
+        """
+        if self.sessionkey is None:
+            return False
+        elif self._is_session_expired():
+            return False
+        else:
+            return True
+
+    def _was_logged_in(self):
+        """
+        Checks if the connector was logged in.
+
+        This checks if the sessionkey is set.
+        :return:
+        """
+        return self.sessionkey is not None
+
+    def _is_session_expired(self):
+        """
+        Checks if the session key is an expired one.
+
+        Hits an endpoint with that key and check response status is 401
+        """
+        url = "{}{}".format(self.uri_base, "/services/data/outputs/tcp/default")
+        self._service.clear_credentials()
+        self.update_headers("Authorization", "Splunk %s" % self.sessionkey)
+        response, content = self._service.request(url, "GET", headers=self.HEADERS)
+        self._service.add_credentials(self._username, self._password)
+        if response["status"] == "401":
+            LOGGER.debug(
+                "Session is expired for RESTconnector %s:%s"
+                % (self.username, self.password)
+            )
+            return True
+        else:
+            LOGGER.debug(
+                "Session is NOT expired for RESTconnector %s:%s"
+                % (self.username, self.password)
+            )
+            return False
+
+    def update_headers(self, key=None, value=None):
+        """
+        Appends a key,value pair to the HEADERS
+
+        @type key: str
+        @param key: key to append to  HEADERS
+        @type value: str
+        @param value: value for that key to append to  HEADERS
+
+        """
+        if key in self.HEADERS:
+            self.HEADERS.pop(key)
+        self.HEADERS.update({key: value})
+
+    def debug_level(self, value):
+        """
+        Overrides default value for debug_level  for httplib service
+
+        @type value: int
+        @param value: debugging level
+
+        """
+
+        self._debug_level = value
+
+    def timeout(self, value):
+        """
+        Overrides default value for timout for http request
+
+        @type value: int
+        @param value: timeout for the http request in seconds
+
+        """
+
+        self._timeout = value
+
+    def disable_ssl_certificate(self, value):
+        """
+        Overrides disable sssl certificate condition
+
+        @type value: bool
+        @param value: enable/disable ssl certificate for auth
+
+        """
+
+        self._disable_ssl_certificate = value
+
+    def follow_redirects(self, value):
+        """
+        Overrides default value of the follow_redircets
+
+        @type value: bool
+        @param value: follow redirects
+
+        """
+
+        self._follow_redirects = value
+
+    def __del__(self):
+        """
+        Called when the object is being deallocated.
+
+        It unregisters itself with the Splunk start listeners.
+
+        """
+        self.splunk.unregister_start_listener(self)
+
+    def __call__(self):
+        """
+        Called when the splunk instance class notifies REST connector listener
+
+        Need  it as local splunk instance notify method invokes l() and then
+        service will be recreated and initialized with default values
+        """
+        self._recreate_service()
+
+    def parse_content_xml(self, content, tag):
+        """
+        Parses the content object (in xml format)
+
+        @type content: xml
+        @param content: content object from http request in xml format
+
+        """
+        dom = parseString(content)
+        xmlTag = dom.getElementsByTagName(tag)[0].toxml()
+        return xmlTag

--- a/pytest_splunk_addon/helmut/exceptions/__init__.py
+++ b/pytest_splunk_addon/helmut/exceptions/__init__.py
@@ -13,3 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from httplib2 import HttpLib2Error
+
+
+class AuthenticationError(HttpLib2Error):
+    """
+    Raised when a login request to Splunk fails.
+    """
+
+    pass

--- a/pytest_splunk_addon/helmut/util/rip.py
+++ b/pytest_splunk_addon/helmut/util/rip.py
@@ -1,0 +1,565 @@
+#
+# Copyright 2021 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import datetime
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+TIMEOUT = 60
+POLL_FREQUENCY = 0.5
+
+
+class TimeoutException(Exception):
+    """
+    Simple timeout exception
+    """
+
+    pass
+
+
+class RESTInPeace:
+    """
+    Simple module to wrap REST endpoints into a consistent set of methods
+    Everything is accessed through servicesNS.
+    """
+
+    # Please keep the key in singular form.
+    URIS = {
+        "alert_action": "/servicesNS/{u}/{a}/admin/alert_actions",
+        "app": "/servicesNS/{u}/{a}/apps",
+        "app_template": "/servicesNS/{u}/{a}/apps/apptemplates",
+        "app_local": "/servicesNS/{u}/{a}/apps/local",
+        "app_install": "/servicesNS/{u}/{a}/apps/appinstall",
+        "automatic_lookup": "/servicesNS/{u}/{a}/data/props/lookups",
+        "calculated_field": "/servicesNS/{u}/{a}/data/props/calcfields",
+        "capabilities": "/servicesNS/{u}/{a}/authorization/capabilities",
+        "changepassword": "/servicesNS/{u}/{a}/authentication/changepassword",
+        "cluster_config": "/servicesNS/{u}/{a}/cluster/config",
+        "cluster_master": "/servicesNS/{u}/{a}/cluster/master",
+        "cluster_searchhead": "/servicesNS/{u}/{a}/cluster/searchhead",
+        "cluster_slave": "/servicesNS/{u}/{a}/cluster/slave",
+        "config": "/servicesNS/{u}/{a}/configs",
+        "conf_event_renderer": ("/servicesNS/{u}/{a}/configs/conf-event_renderers"),
+        "conf_saved_searches": "/servicesNS/{u}/{a}/configs/conf-savedsearches",
+        "datamodel": "/servicesNS/{u}/{a}/datamodel/model",
+        "datamodel_acceleration": "/servicesNS/{u}/{a}/datamodel/acceleration",
+        "datamodel_report": "/servicesNS/{u}/{a}/datamodel/report",
+        "deployment_client_config": ("/servicesNS/{u}/{a}/deployment/client/config"),
+        "deployment_server_class": (
+            "/servicesNS/{u}/{a}/deployment/server/serverclasses"
+        ),
+        "deployment_server_config": ("/servicesNS/{u}/{a}/deployment/server/config"),
+        "deployment_server_client": ("/servicesNS/{u}/{a}/deployment/server/clients"),
+        "deployment_server_application": (
+            "/servicesNS/{u}/{a}/deployment/server/applications"
+        ),
+        "distsearch_peer": "/servicesNS/{u}/{a}/search/distributed/peers",
+        "eventtype": "/servicesNS/{u}/{a}/saved/eventtypes",
+        "fired_alert": "/servicesNS/{u}/{a}/alerts/fired_alerts",
+        "field": "/servicesNS/{u}/{a}/search/fields",
+        "field_alias": "/servicesNS/{u}/{a}/data/props/fieldaliases",
+        "field_extraction": "/servicesNS/{u}/{a}/data/props/extractions",
+        "fvtag": "/servicesNS/{u}/{a}/saved/fvtags",
+        "httpauth_token": "/servicesNS/{u}/{a}/authentication/httpauth-tokens",
+        "index": "/servicesNS/{u}/{a}/data/indexes",
+        "input": "/servicesNS/{u}/{a}/data/inputs",
+        "input_monitor": "/servicesNS/{u}/{a}/data/inputs/monitor",
+        "input_oneshot": "/servicesNS/{u}/{a}/data/inputs/oneshot",
+        "input_script": "/servicesNS/{u}/{a}/data/inputs/script",
+        "input_tcp_cooked": "/servicesNS/{u}/{a}/data/inputs/tcp/cooked",
+        "input_tcp_raw": "/servicesNS/{u}/{a}/data/inputs/tcp/raw",
+        "input_udp": "/servicesNS/{u}/{a}/data/inputs/udp",
+        "input_eventlog": ("/servicesNS/{u}/{a}/data/inputs/win-event-log-collections"),
+        "input_regmon": "/servicesNS/{u}/{a}/data/inputs/WinRegMon",
+        "input_perfmon": "/servicesNS/{u}/{a}/data/inputs/win-perfmon",
+        "input_hostmon": "/servicesNS/{u}/{a}/data/inputs/WinHostMon",
+        "input_netmon": "/servicesNS/{u}/{a}/data/inputs/WinNetMon",
+        "input_admon": "/servicesNS/{u}/{a}/data/inputs/ad",
+        "input_printmon": "/servicesNS/{u}/{a}/data/inputs/WinPrintMon",
+        "job": "/servicesNS/{u}/{a}/search/jobs",
+        "ldap_strategy": "/servicesNS/{u}/{a}/authentication/providers/LDAP",
+        "license": "/servicesNS/{u}/{a}/licenser/licenses",
+        "licenser": "/servicesNS/{u}/{a}/licenser",
+        "licenser_group": "/servicesNS/{u}/{a}/licenser/groups",
+        "lookup": "/servicesNS/{u}/{a}/data/props/lookups",
+        "lookup_table_file": "/servicesNS/{u}/{a}/data/lookup-table-files",
+        "macro": "/servicesNS/{u}/{a}/admin/macros",
+        "message": "/servicesNS/{u}/{a}/messages",
+        "navigation": "/servicesNS/{u}/{a}/data/ui/nav",
+        "ntag": "/servicesNS/{u}/{a}/saved/ntags",
+        "panel": "/servicesNS/{u}/{a}/data/ui/panels",
+        "property": "/servicesNS/{u}/{a}/properties",
+        "role": "/servicesNS/{u}/{a}/authorization/roles",
+        # only simple and stream available, and only edit method works.
+        "receiver": "/services/receivers",
+        "saved_search": "/servicesNS/{u}/{a}/saved/searches",
+        "scheduled_view": "/servicesNS/{u}/{a}/scheduled/views",
+        "search_command": "/servicesNS/{u}/{a}/admin/commandsconf",
+        "search_head_cluster": "/servicesNS/{u}/{a}/shcluster",
+        "server": "/servicesNS/{u}/{a}/server",
+        "sourcetype": "/servicesNS/{u}/{a}/saved/sourcetypes",
+        "sourcetype_rename": "/servicesNS/{u}/{a}/saved/sourcetype-rename",
+        "tag": "/servicesNS/{u}/{a}/search/tags",
+        "tcp_output_group": "/servicesNS/{u}/{a}/data/outputs/tcp/group",
+        "time": "/servicesNS/{u}/{a}/data/ui/times",
+        "transforms_extraction": ("/servicesNS/{u}/{a}/data/transforms/extractions"),
+        "transforms_lookup": "/servicesNS/{u}/{a}/data/transforms/lookups",
+        "transparent_summarization": "/servicesNS/{u}/{a}/admin/summarization",
+        "user": "/servicesNS/{u}/{a}/authentication/users",
+        "ui_manager": "/servicesNS/{u}/{a}/data/ui/manager",
+        "ui_pref": "/servicesNS/{u}/{a}/data/ui/prefs",
+        "ui_tour": "/servicesNS/{u}/{a}/data/ui/ui-tour",
+        "user_pref": "/servicesNS/{u}/{a}/admin/user-prefs",
+        "view": "/servicesNS/{u}/{a}/data/ui/views",
+        "viewstate": "/servicesNS/{u}/{a}/data/ui/viewstates",
+        "vix_index": "/servicesNS/{u}/{a}/data/vix-indexes",
+        "vix_provider": "/servicesNS/{u}/{a}/data/vix-providers",
+        "workflow_action": "/servicesNS/{u}/{a}/data/ui/workflow-actions",
+    }
+
+    # This list contains function-like URIs.
+    # Please keep the key in singular form.
+    FUNCTION_URIS = {
+        "generate_regex": "/servicesNS/{u}/{a}/field_extractor/generate_regex",
+    }
+
+    SUCCESS = {"GET": "200", "POST": "201", "DELETE": "200"}
+
+    def __init__(self, helmut_rest_connector, user_namespace=None, app_namespace=None):
+        """
+        Pass in a logged-in helmut rest connector. Every call afterwards
+        will use this connector. Namespaces should be encapsulated inside
+        the connector.
+        """
+
+        self.conn = helmut_rest_connector
+
+        if user_namespace is not None and app_namespace is not None:
+            self._user = user_namespace
+            self._app = app_namespace
+        else:
+            self._user, self._app = self.conn.namespace.strip("/").split("/")
+
+        self.change_namespace(self._user, self._app)
+
+    def change_namespace(self, user, app):
+        """
+        Change the user/app namespace for all the rest calls.
+        Note: This does NOT change the user making the rest calls.
+
+        @rtype user: string
+        @param user: username
+
+        @rtype app: string
+        @param app: app id
+        """
+        self._user = urllib.parse.quote(user, "")
+        self._app = app
+
+        for uri_name, uri_value in list(self.URIS.items()):
+            final_uri_value = uri_value.format(u=self._user, a=self._app)
+            self.add_endpoint(uri_name, final_uri_value)
+        for uri_name, uri_value in list(self.FUNCTION_URIS.items()):
+            final_uri_value = uri_value.format(u=self._user, a=self._app)
+            self.add_function_endpoint(uri_name, final_uri_value)
+
+    def add_endpoint(self, uri_name, uri_value):
+        """
+        Creates generic create, edit, delete, check methods for the
+        given endpoint name and value.
+
+        @type uri_name: string
+        @param uri_name: the name of the endpoint
+
+        @type uri_value: string
+        @param uri_name: the uri for the endpoint
+        """
+
+        def gen_create(*args, **kwargs):
+            """
+            Create
+            """
+            if args:
+                if kwargs:
+                    args = args[0] + list(kwargs.items())
+                body = args
+            else:
+                body = kwargs
+
+            return self.conn.make_request("POST", uri_value, body=body)
+
+        gen_create.__doc__ = """
+            Create method for the '{ep}' endpoint.
+            - uri: '{uri}'
+
+            @return: the return value from the make_request on the endpoint
+            """.format(
+            ep=uri_name, uri=uri_value
+        )
+        gen_create.__name__ = f"create_{uri_name}"
+        setattr(self, gen_create.__name__, gen_create)
+
+        def gen_get(id_name, sub_endpoint="", *args, **kwargs):
+            """
+            Get
+            """
+            uri = "{uri}/{id}{sub_ep}".format(
+                uri=uri_value,
+                id=urllib.parse.quote(id_name, safe=""),
+                sub_ep=(
+                    sub_endpoint
+                    if (sub_endpoint == "" or sub_endpoint.startswith("/"))
+                    else f"/{sub_endpoint}"
+                ),
+            )
+            return self.conn.make_request("GET", uri, args, kwargs)
+
+        gen_get.__doc__ = """
+            Get method for the '{ep}' endpoint.
+            - uri: '{uri}'
+
+            @type id_name: string
+            @param: id_name: the id of the object.
+
+            @type sub_endpoint: string
+            @param sub_endpoint: child endpoint of the base endpoint
+
+            @return: the return value from the make_request on the endpoint
+            """.format(
+            ep=uri_name, uri=uri_value
+        )
+        gen_get.__name__ = f"get_{uri_name}"
+        setattr(self, gen_get.__name__, gen_get)
+
+        def gen_reload(*args, **kwargs):
+            """
+            Get
+            """
+            uri = f"{uri_value}/_reload"
+            return self.conn.make_request("GET", uri, args, kwargs)
+
+        gen_reload.__doc__ = """
+            Reload method for the '{ep}' endpoint.
+            - uri: '{uri}/_reload'
+            - uses the '_reload' endpoint off the base endpoing regardless
+              of the object.
+
+            Note: NOT all REST endpoints support this, please check your endpoint
+                  before attempting to do this.
+
+            @return: the return value from the make_request on the endpoint
+            """.format(
+            ep=uri_name, uri=uri_value
+        )
+        gen_reload.__name__ = f"reload_{uri_name}"
+        setattr(self, gen_reload.__name__, gen_reload)
+
+        def gen_get_all(*args, **kwargs):
+            """
+            Get
+            """
+            return self.conn.make_request("GET", uri_value, args, kwargs)
+
+        gen_get_all.__doc__ = """
+            Get all method for the '{ep}' endpoint.
+            - uri: '{uri}'
+
+            @type id_name: string
+            @param: id_name: the id of the object.
+
+            @return: the return value from the make_request on the endpoint
+            """.format(
+            ep=uri_name, uri=uri_value
+        )
+        gen_get_all.__name__ = f"get_all_{uri_name}"
+        setattr(self, gen_get_all.__name__, gen_get_all)
+
+        def gen_edit(id_name, sub_endpoint="", urlparam=None, *args, **kwargs):
+            """
+            Edit
+            """
+            if args:
+                if kwargs:
+                    args = args[0] + list(kwargs.items())
+                body = args
+            else:
+                body = kwargs
+
+            uri = "{uri}/{id}{sub_ep}".format(
+                uri=uri_value,
+                id=urllib.parse.quote(id_name, safe=""),
+                sub_ep=(
+                    sub_endpoint
+                    if (sub_endpoint == "" or sub_endpoint.startswith("/"))
+                    else f"/{sub_endpoint}"
+                ),
+            )
+
+            return self.conn.make_request("POST", uri=uri, urlparam=urlparam, body=body)
+
+        gen_edit.__doc__ = """
+            Edit method for the '{ep}' endpoint.
+            - uri: '{uri}'
+
+            @type id_name: string
+            @param: id_name: the id of the object.
+
+            @type sub_endpoint: string
+            @param sub_endpoint: child endpoint of the base endpoint
+
+            @return: the return value from the make_request on the endpoint
+            """.format(
+            ep=uri_name, uri=uri_value
+        )
+        gen_edit.__name__ = f"edit_{uri_name}"
+        setattr(self, gen_edit.__name__, gen_edit)
+
+        def gen_delete(id_name, *args, **kwargs):
+            """
+            Delete
+            """
+            uri = "{uri}/{id}".format(
+                uri=uri_value, id=urllib.parse.quote(id_name, safe="")
+            )
+            return self.conn.make_request("DELETE", uri, args, kwargs)
+
+        gen_delete.__doc__ = """
+            Delete method for the '{ep}' endpoint.
+            - uri: '{uri}'
+
+            @type id_name: string
+            @param: id_name: the id of the object.
+
+            @return: the return value from the make_request on the endpoint
+            """.format(
+            ep=uri_name, uri=uri_value
+        )
+        gen_delete.__name__ = f"delete_{uri_name}"
+        setattr(self, gen_delete.__name__, gen_delete)
+
+        def gen_check(id_name, *args, **kwargs):
+            """
+            Check
+            """
+            if not id_name:
+                # invalid id_name, so we'll return False.
+                return False
+
+            if args:
+                if kwargs:
+                    args = args[0] + list(kwargs.items())
+                body = args
+            else:
+                body = kwargs
+
+            uri = "{uri}/{id}".format(
+                uri=uri_value, id=urllib.parse.quote(id_name, safe="")
+            )
+            response = self.conn.make_request("GET", uri, body=body)[0]
+            return response["status"] == self.SUCCESS["GET"]
+
+        gen_check.__doc__ = """
+            Check method for the '{ep}' endpoint.
+            - uri: '{uri}'
+
+            @type id_name: string
+            @param: id_name: the id of the object.
+
+            @rtype: boolean
+            @return: True if the object exists and False otherwise.
+            """.format(
+            ep=uri_name, uri=uri_value
+        )
+        gen_check.__name__ = f"check_{uri_name}"
+        setattr(self, gen_check.__name__, gen_check)
+
+        def gen_wait_to_be_created(
+            id_name, timeout=TIMEOUT, poll_frequency=POLL_FREQUENCY, *args, **kwargs
+        ):
+            """
+            Wait for the specific item to be created.
+
+            @type timeout: int
+            @param timeout: the number in second to poll for.
+
+            @type poll_frequency: number
+            @param poll_frequency: the number in seconds to wait between
+                                   each poll
+            """
+            if args:
+                if kwargs:
+                    args = args[0] + list(kwargs.items())
+                body = args
+            else:
+                body = kwargs
+
+            uri = "{uri}/{id}".format(
+                uri=uri_value, id=urllib.parse.quote(id_name, safe="")
+            )
+
+            start_time = datetime.datetime.now()
+            response = self.conn.make_request("GET", uri, body=body)[0]
+
+            while (
+                response["status"] != self.SUCCESS["GET"]
+                and (datetime.datetime.now() - start_time).seconds < timeout
+            ):
+                time.sleep(poll_frequency)
+                response = self.conn.make_request("GET", uri, body=body)[0]
+
+            if response["status"] != self.SUCCESS["GET"]:
+                raise TimeoutException(
+                    "The entity '{uri}/{id}' was not found after {t} "
+                    "seconds.".format(
+                        uri=uri_value,
+                        id=urllib.parse.quote(id_name, safe=""),
+                        t=timeout,
+                    )
+                )
+
+        gen_wait_to_be_created.__doc__ = """
+            Wait to be created method for the '{ep}' endpoint.
+            - uri: '{uri}'
+
+            @type id_name: string
+            @param: id_name: the id of the object.
+
+            @type timeout: int
+            @param timeout: the number in second to poll for.
+
+            @type poll_frequency: number
+            @param poll_frequency: the number in seconds to wait between
+                                   each poll
+            """.format(
+            ep=uri_name, uri=uri_value
+        )
+        gen_wait_to_be_created.__name__ = "wait_for_{ep}_to_be_created".format(
+            ep=uri_name
+        )
+        setattr(self, gen_wait_to_be_created.__name__, gen_wait_to_be_created)
+
+        def gen_wait_to_be_deleted(
+            id_name, timeout=TIMEOUT, poll_frequency=POLL_FREQUENCY, *args, **kwargs
+        ):
+            """
+            Wait for the specific item to be deleted.
+
+            @type timeout: int
+            @param timeout: the number in second to poll for.
+
+            @type poll_frequency: number
+            @param poll_frequency: the number in seconds to wait between
+                                   each poll
+            """
+            if args:
+                if kwargs:
+                    args = args[0] + list(kwargs.items())
+                body = args
+            else:
+                body = kwargs
+
+            uri = "{uri}/{id}".format(
+                uri=uri_value, id=urllib.parse.quote(id_name, safe="")
+            )
+
+            start_time = datetime.datetime.now()
+            response = self.conn.make_request("GET", uri, body=body)[0]
+
+            while (
+                response["status"] == self.SUCCESS["GET"]
+                and (datetime.datetime.now() - start_time).seconds < timeout
+            ):
+                time.sleep(poll_frequency)
+                response = self.conn.make_request("GET", uri, body=body)[0]
+
+            if response["status"] == self.SUCCESS["GET"]:
+                raise TimeoutException(
+                    "The entity '{uri}/{id}' was still found after {t} "
+                    "seconds.".format(
+                        uri=uri_value,
+                        id=urllib.parse.quote(id_name, safe=""),
+                        t=timeout,
+                    )
+                )
+
+        gen_wait_to_be_deleted.__doc__ = """
+            Wait to be deleted method for the '{ep}' endpoint.
+            - uri: '{uri}'
+
+            @type id_name: string
+            @param: id_name: the id of the object.
+
+            @type timeout: int
+            @param timeout: the number in second to poll for.
+
+            @type poll_frequency: number
+            @param poll_frequency: the number in seconds to wait between
+                                   each poll
+            """.format(
+            ep=uri_name, uri=uri_value
+        )
+        gen_wait_to_be_deleted.__name__ = "wait_for_{ep}_to_be_deleted".format(
+            ep=uri_name
+        )
+        setattr(self, gen_wait_to_be_deleted.__name__, gen_wait_to_be_deleted)
+
+    def add_function_endpoint(self, uri_name, uri_value):
+        """
+        Creates generic run methods for the
+        given endpoint name and value.
+
+        @type uri_name: string
+        @param uri_name: the name of the endpoint
+
+        @type uri_value: string
+        @param uri_name: the uri for the endpoint
+        """
+
+        def gen_run(sub_endpoint="", *args, **kwargs):
+            """
+            Acting like calling a function, send GET request
+            to the specific endpoint and return value from the make_request.
+
+            @type sub_endpoint: string
+            @param sub_endpoint: child endpoint of the base endpoint
+
+            @return: the return value from the make_request on the endpoint
+            """
+            uri = "{uri}/{sub_ep}".format(
+                uri=uri_value,
+                sub_ep=(
+                    sub_endpoint
+                    if (sub_endpoint == "" or sub_endpoint.startswith("/"))
+                    else f"/{sub_endpoint}"
+                ),
+            )
+            return self.conn.make_request("GET", uri, args, kwargs)
+
+        gen_run.__doc__ = """
+            Acting like calling a function, send GET request to the
+            '{ep}' endpoint and return value from the make_request.
+            - uri: '{uri}'
+
+            @type sub_endpoint: string
+            @param sub_endpoint: child endpoint of the base endpoint
+
+            @return: the return value from the make_request on the endpoint
+            """.format(
+            ep=uri_name, uri=uri_value
+        )
+        gen_run.__name__ = f"run_{uri_name}"
+        setattr(self, gen_run.__name__, gen_run)


### PR DESCRIPTION
The reason for it is that some of the modinput tests are using some
of the unpredicted paths of PSA, REST connector in this case.

This is a temporary fix and will be removed as soon as we have time to
refactor modinput tests in some of the repositories (around 12 atm).