### PR TITLE
chore: SMEs now own data_models

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @arys-splunk
+pytest_splunk_addon/standard_lib/data_models @rkent-splunk @alexeisuv @justin-splunk

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 * @arys-splunk
-pytest_splunk_addon/standard_lib/data_models @rkent-splunk @alexeisuv @justin-splunk
+pytest_splunk_addon/standard_lib/data_models @splunk/products-gdi-sme


### PR DESCRIPTION
As requested, adding SME team to be asked to review changes related to `pytest_splunk_addon/standard_lib/data_models` folder.