### PR TITLE
fix: checkpoint cef format issue

### DIFF
--- a/pytest_splunk_addon/standard_lib/requirement_tests/test_generator.py
+++ b/pytest_splunk_addon/standard_lib/requirement_tests/test_generator.py
@@ -86,8 +86,15 @@ class ReqsTestGenerator:
             r"\s(CEF:\d\|[^\|]+\|([^\|]+)\|[^\|]+\|[^\|]+\|[^\|]+\|([^\|]+)\|(.*))",
             raw_event,
         )
+        CEF_checkpoint_match = re.search(
+            r"(time=\d+\|[^\|]+\|([^\|]+)\|[^\|]+\|[^\|]+\|[^\|]+\|([^\|]+)\|(.*))",
+            raw_event,
+        )
         if CEF_format_match:
             stripped_header = CEF_format_match.group(1)
+            return stripped_header
+        if CEF_checkpoint_match:
+            stripped_header = CEF_checkpoint_match.group(1)
             return stripped_header
         regex_rfc5424 = re.search(
             r"(?:(\d{4}[-]\d{2}[-]\d{2}[T]\d{2}[:]\d{2}[:]\d{2}(?:\.\d{1,6})?(?:[+-]\d{2}[:]\d{2}|Z)?)|-)\s(?:([\w][\w\d\.@-]*)|-)\s(.*)$",

--- a/tests/unit/tests_standard_lib/test_requirement_tests/test_test_generator.py
+++ b/tests/unit/tests_standard_lib/test_requirement_tests/test_test_generator.py
@@ -165,6 +165,32 @@ def test_extract_params():
             [{"field1": "value1", "field2": "value2"}, {"field3": "value3"}],
             [],
         ),
+        (
+            ["requirement_checkpoint.log"],
+            [True],
+            ["syslog"],
+            {
+                "event": [
+                    "time=1611840576|hostname=test_name|severity=Critical|confidence_level=High|product=test_product|action=Detect|ifdir=inbound|loguid=test "
+                ]
+            },
+            [["model_1:dataset_1"]],
+            ["event_name_1"],
+            [{"field1": "value1", "field2": "value2"}, {"field3": "value3"}],
+            [
+                (
+                    {
+                        "model_list": [("model_1", "dataset_1", "")],
+                        "escaped_event": "time=1611840576|hostname=test_name|severity=Critical|confidence_level=High|product=test_product|action=Detect|ifdir=inbound|loguid=test",
+                        "exceptions_dict": {"field3": "value3"},
+                        "Key_value_dict": {"field1": "value1", "field2": "value2"},
+                        "modinput_params": None,
+                        "transport_type": "syslog",
+                    },
+                    "model_1:dataset_1::fake_path/requirement_checkpoint.log::event_no::1::event_name::event_name_1",
+                ),
+            ],
+        ),
     ],
 )
 def test_generate_cim_req_params(


### PR DESCRIPTION
Handle checkpoint CEF log.
CEF format sample- 
```
Jan 11 10:25:39 host CEF:Version|Device Vendor|Device Product|Device Version|Device Event Class ID|Name|Severity|[Extension]
```
Checkpoint format sample-
```
time=1611840576|hostname=r81-t279-leui-main-take-2|severity=Critical|confidence_level=High|product=Anti Malware New Anti Virus|action=Detect|ifdir=inbound|loguid= .....
```
In the case of Checkpoint CEF is missing the header. Hence generic CEF regex does not work for checkpoint logs.


Have not added a test- as checkpoint TA is not present and the test will fail as DM mapping and field level tests won't work