### PR TITLE
fix: sourcetype mismatch between ingested vs requirement file

### DIFF
--- a/pytest_splunk_addon/standard_lib/requirement_tests/test_templates.py
+++ b/pytest_splunk_addon/standard_lib/requirement_tests/test_templates.py
@@ -167,11 +167,20 @@ class ReqsTestTemplates(object):
             "modular input",
             "modular_input",
             "Mod Input",
+            "dbx",
+            "windows_input",
+            "hec_event",
+            "scripted_input",
+            "scripted input",
+            "hec_raw",
+            "file_monitor",
         ):
             host = modinput_params["host"]
             source = modinput_params["source"]
-            sourcetype = modinput_params["sourcetype"]
-            search = f'search index=* host="{host}" source="{source}" sourcetype="{sourcetype}" {escaped_event}|fields * '
+            sourcetype_req_file = modinput_params["sourcetype"]
+            # Removing sourcetype from search ADDON-50593
+            search = f'search index=* host="{host}" source="{source}" {escaped_event}|fields * '
+            # search = f'search index=* host="{host}" source="{source}" sourcetype="{sourcetype}" {escaped_event}|fields * '
         else:
             search = f"search index=* {escaped_event} |fields * "
         ingestion_check = splunk_search_util.checkQueryCountIsGreaterThanZero(
@@ -214,4 +223,5 @@ class ReqsTestTemplates(object):
             f" Field_extraction_check: {field_extraction_check} \n"
             f" Field extraction errors: {json.dumps(missing_key_value, indent=4)} \n"
             f" sourcetype of ingested event: {sourcetype} \n"
+            f" sourcetype in requirement file event: {sourcetype_req_file} \n"
         )

--- a/pytest_splunk_addon/standard_lib/requirement_tests/test_templates.py
+++ b/pytest_splunk_addon/standard_lib/requirement_tests/test_templates.py
@@ -156,6 +156,8 @@ class ReqsTestTemplates(object):
         modinput_params = splunk_searchtime_requirement_param["modinput_params"]
         transport_type = splunk_searchtime_requirement_param["transport_type"]
         logging.info(exceptions_dict)
+        # Cases where sourcetype is not defined in req file
+        sourcetype_req_file = None
         # search = f" search source= pytest_splunk_addon:hec:raw sourcetype={sourcetype} {escaped_event} |fields * "
         # removed source and sourcetype as sc4s assigns it based on event
         if transport_type in (


### PR DESCRIPTION
In the MSCS TA, Input source type i.e  mscs:azure:event hub  but after transforming the event source type will be azure:monitor:aad, azure:eventhub:cosmosdb. These transformation cause ingestion failure in requirement test.
Many other TA's are affected too. Hence remove source type from search
https://splunk.atlassian.net/browse/ADDON-50593
