### PR TITLE
fix: SC4S latest container location

### DIFF
--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -34,7 +34,7 @@ services:
       - results:/work/test-results
 
   sc4s:
-    image: splunk/scs:latest
+    image: ghcr.io/splunk/splunk-connect-for-syslog/container2:latest
     hostname: sc4s
     #When this is enabled test_common will fail
     #    command: -det

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ version: "3.7"
 services:
 
   sc4s:
-    image: splunk/scs:latest
+    image: ghcr.io/splunk/splunk-connect-for-syslog/container2:latest
     hostname: sc4s
     #When this is enabled test_common will fail
     #    command: -det


### PR DESCRIPTION
SC4S publishes the latest images on Github now than docker hub
Updating path for pytest splunk addon
Updated in addon template too https://github.com/splunk/addonfactory-repository-template/pull/252
