### PR TITLE
fix: manual release trigger

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@
 #
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
     -   id: check-merge-conflict
     -   id: debug-statements


### PR DESCRIPTION
The release step was broken due to wrong credentials and we need to
retrigger release.