### PR TITLE
feat: replacing req unit tests

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -8,7 +8,8 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
   pull_request:
-    branches: [main, develop]
+    branches:
+      - "**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -31,6 +31,7 @@ header:
     - "tests/**"
     - ".*"
     - "pytest_splunk_addon/standard_lib/**/*.json"
+    - "pytest_splunk_addon/standard_lib/**/*.xsd"
     - "MANIFEST.in"
     - "entrypoint.sh"
     - "pytest_splunk_addon/.ignore_splunk_internal_errors"

--- a/poetry.lock
+++ b/poetry.lock
@@ -57,7 +57,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "coverage"
-version = "6.4.1"
+version = "6.4.2"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
@@ -76,6 +76,17 @@ description = "XML bomb protection for Python stdlib modules"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "elementpath"
+version = "2.5.3"
+description = "XPath 1.0/2.0/3.0 parsers and selectors for ElementTree and lxml"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+dev = ["tox", "coverage", "lxml", "xmlschema (>=1.9.0)", "sphinx", "memory-profiler", "flake8", "mypy (==0.950)"]
 
 [[package]]
 name = "execnet"
@@ -470,6 +481,22 @@ secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "cer
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
+name = "xmlschema"
+version = "1.11.3"
+description = "An XML Schema validator and decoder"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+elementpath = ">=2.5.0,<3.0.0"
+
+[package.extras]
+codegen = ["elementpath (>=2.5.0,<3.0.0)", "jinja2"]
+dev = ["tox", "coverage", "lxml", "elementpath (>=2.5.0,<3.0.0)", "memory-profiler", "sphinx", "sphinx-rtd-theme", "jinja2", "flake8", "mypy", "lxml-stubs"]
+docs = ["elementpath (>=2.5.0,<3.0.0)", "sphinx", "sphinx-rtd-theme", "jinja2"]
+
+[[package]]
 name = "xmltodict"
 version = "0.13.0"
 description = "Makes working with XML feel like you are working with JSON"
@@ -495,7 +522,7 @@ docker = ["lovely-pytest-docker"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "124c6ad580e9f095a4807942a22aa37b88c6d6b8305e77933d349f89df2a620f"
+content-hash = "15cea77e96c668d1b6faacf17641800fc6a45c35230f5f672687be2e9f6b271f"
 
 [metadata.files]
 addonfactory-splunk-conf-parser-lib = [
@@ -522,53 +549,12 @@ colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
-coverage = [
-    {file = "coverage-6.4.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f1d5aa2703e1dab4ae6cf416eb0095304f49d004c39e9db1d86f57924f43006b"},
-    {file = "coverage-6.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4ce1b258493cbf8aec43e9b50d89982346b98e9ffdfaae8ae5793bc112fb0068"},
-    {file = "coverage-6.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83c4e737f60c6936460c5be330d296dd5b48b3963f48634c53b3f7deb0f34ec4"},
-    {file = "coverage-6.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:84e65ef149028516c6d64461b95a8dbcfce95cfd5b9eb634320596173332ea84"},
-    {file = "coverage-6.4.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f69718750eaae75efe506406c490d6fc5a6161d047206cc63ce25527e8a3adad"},
-    {file = "coverage-6.4.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e57816f8ffe46b1df8f12e1b348f06d164fd5219beba7d9433ba79608ef011cc"},
-    {file = "coverage-6.4.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:01c5615d13f3dd3aa8543afc069e5319cfa0c7d712f6e04b920431e5c564a749"},
-    {file = "coverage-6.4.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:75ab269400706fab15981fd4bd5080c56bd5cc07c3bccb86aab5e1d5a88dc8f4"},
-    {file = "coverage-6.4.1-cp310-cp310-win32.whl", hash = "sha256:a7f3049243783df2e6cc6deafc49ea123522b59f464831476d3d1448e30d72df"},
-    {file = "coverage-6.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:ee2ddcac99b2d2aec413e36d7a429ae9ebcadf912946b13ffa88e7d4c9b712d6"},
-    {file = "coverage-6.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fb73e0011b8793c053bfa85e53129ba5f0250fdc0392c1591fd35d915ec75c46"},
-    {file = "coverage-6.4.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:106c16dfe494de3193ec55cac9640dd039b66e196e4641fa8ac396181578b982"},
-    {file = "coverage-6.4.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87f4f3df85aa39da00fd3ec4b5abeb7407e82b68c7c5ad181308b0e2526da5d4"},
-    {file = "coverage-6.4.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:961e2fb0680b4f5ad63234e0bf55dfb90d302740ae9c7ed0120677a94a1590cb"},
-    {file = "coverage-6.4.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:cec3a0f75c8f1031825e19cd86ee787e87cf03e4fd2865c79c057092e69e3a3b"},
-    {file = "coverage-6.4.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:129cd05ba6f0d08a766d942a9ed4b29283aff7b2cccf5b7ce279d50796860bb3"},
-    {file = "coverage-6.4.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:bf5601c33213d3cb19d17a796f8a14a9eaa5e87629a53979a5981e3e3ae166f6"},
-    {file = "coverage-6.4.1-cp37-cp37m-win32.whl", hash = "sha256:269eaa2c20a13a5bf17558d4dc91a8d078c4fa1872f25303dddcbba3a813085e"},
-    {file = "coverage-6.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:f02cbbf8119db68455b9d763f2f8737bb7db7e43720afa07d8eb1604e5c5ae28"},
-    {file = "coverage-6.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ffa9297c3a453fba4717d06df579af42ab9a28022444cae7fa605af4df612d54"},
-    {file = "coverage-6.4.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:145f296d00441ca703a659e8f3eb48ae39fb083baba2d7ce4482fb2723e050d9"},
-    {file = "coverage-6.4.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d44996140af8b84284e5e7d398e589574b376fb4de8ccd28d82ad8e3bea13"},
-    {file = "coverage-6.4.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2bd9a6fc18aab8d2e18f89b7ff91c0f34ff4d5e0ba0b33e989b3cd4194c81fd9"},
-    {file = "coverage-6.4.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3384f2a3652cef289e38100f2d037956194a837221edd520a7ee5b42d00cc605"},
-    {file = "coverage-6.4.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:9b3e07152b4563722be523e8cd0b209e0d1a373022cfbde395ebb6575bf6790d"},
-    {file = "coverage-6.4.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:1480ff858b4113db2718848d7b2d1b75bc79895a9c22e76a221b9d8d62496428"},
-    {file = "coverage-6.4.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:865d69ae811a392f4d06bde506d531f6a28a00af36f5c8649684a9e5e4a85c83"},
-    {file = "coverage-6.4.1-cp38-cp38-win32.whl", hash = "sha256:664a47ce62fe4bef9e2d2c430306e1428ecea207ffd68649e3b942fa8ea83b0b"},
-    {file = "coverage-6.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:26dff09fb0d82693ba9e6231248641d60ba606150d02ed45110f9ec26404ed1c"},
-    {file = "coverage-6.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d9c80df769f5ec05ad21ea34be7458d1dc51ff1fb4b2219e77fe24edf462d6df"},
-    {file = "coverage-6.4.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:39ee53946bf009788108b4dd2894bf1349b4e0ca18c2016ffa7d26ce46b8f10d"},
-    {file = "coverage-6.4.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f5b66caa62922531059bc5ac04f836860412f7f88d38a476eda0a6f11d4724f4"},
-    {file = "coverage-6.4.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fd180ed867e289964404051a958f7cccabdeed423f91a899829264bb7974d3d3"},
-    {file = "coverage-6.4.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:84631e81dd053e8a0d4967cedab6db94345f1c36107c71698f746cb2636c63e3"},
-    {file = "coverage-6.4.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:8c08da0bd238f2970230c2a0d28ff0e99961598cb2e810245d7fc5afcf1254e8"},
-    {file = "coverage-6.4.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:d42c549a8f41dc103a8004b9f0c433e2086add8a719da00e246e17cbe4056f72"},
-    {file = "coverage-6.4.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:309ce4a522ed5fca432af4ebe0f32b21d6d7ccbb0f5fcc99290e71feba67c264"},
-    {file = "coverage-6.4.1-cp39-cp39-win32.whl", hash = "sha256:fdb6f7bd51c2d1714cea40718f6149ad9be6a2ee7d93b19e9f00934c0f2a74d9"},
-    {file = "coverage-6.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:342d4aefd1c3e7f620a13f4fe563154d808b69cccef415415aece4c786665397"},
-    {file = "coverage-6.4.1-pp36.pp37.pp38-none-any.whl", hash = "sha256:4803e7ccf93230accb928f3a68f00ffa80a88213af98ed338a57ad021ef06815"},
-    {file = "coverage-6.4.1.tar.gz", hash = "sha256:4321f075095a096e70aff1d002030ee612b65a205a0a0f5b815280d5dc58100c"},
-]
+coverage = []
 defusedxml = [
     {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
     {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
 ]
+elementpath = []
 execnet = [
     {file = "execnet-1.9.0-py2.py3-none-any.whl", hash = "sha256:a295f7cc774947aac58dde7fdc85f4aa00c42adf5d8f5468fc630c1acf30a142"},
     {file = "execnet-1.9.0.tar.gz", hash = "sha256:8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5"},
@@ -718,6 +704,7 @@ urllib3 = [
     {file = "urllib3-1.26.8-py2.py3-none-any.whl", hash = "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed"},
     {file = "urllib3-1.26.8.tar.gz", hash = "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"},
 ]
+xmlschema = []
 xmltodict = [
     {file = "xmltodict-0.13.0-py2.py3-none-any.whl", hash = "sha256:aa89e8fd76320154a40d19a0df04a4695fb9dc5ba977cbb68ab3e4eb225e7852"},
     {file = "xmltodict-0.13.0.tar.gz", hash = "sha256:341595a488e3e01a85a9d8911d8912fd922ede5fecc4dce437eb4b6c8d037e56"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ addonfactory-splunk-conf-parser-lib = "^0.3.3"
 defusedxml = "^0.7.1"
 Faker = "^13.12.0"
 xmltodict = "^0.13.0"
+xmlschema = "^1.11.3"
 
 [tool.poetry.extras]
 docker = ['lovely-pytest-docker']

--- a/pytest_splunk_addon/plugin.py
+++ b/pytest_splunk_addon/plugin.py
@@ -27,7 +27,6 @@ test_generator = None
 
 
 def pytest_configure(config):
-    global test_generator
     """
     Setup configuration after command-line options are parsed
     """
@@ -78,8 +77,6 @@ def pytest_configure(config):
         "markers",
         "splunk_searchtime_requirements: Test an requirement test only  is mapped with only one data models",
     )
-    if config.getoption("splunk_app", None):
-        test_generator = AppTestGenerator(config)
 
     cim_report = config.getoption("cim_report")
     if cim_report and not hasattr(config, "slaveinput"):
@@ -96,7 +93,7 @@ def pytest_unconfigure(config):
 
 
 def pytest_sessionstart(session):
-
+    global test_generator
     SampleXdistGenerator.event_path = session.config.getoption("event_path")
     SampleXdistGenerator.event_stored = False
     SampleXdistGenerator.tokenized_event_source = session.config.getoption(
@@ -114,6 +111,8 @@ def pytest_sessionstart(session):
         store_events = session.config.getoption("store_events")
         sample_generator = SampleXdistGenerator(app_path, config_path)
         sample_generator.get_samples(store_events)
+    if session.config.getoption("splunk_app", None):
+        test_generator = AppTestGenerator(session.config)
 
 
 def pytest_generate_tests(metafunc):

--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -804,6 +804,16 @@ def file_system_prerequisite():
 
 @pytest.fixture(scope="session")
 def splunk_dm_recommended_fields(splunk_search_util):
+    """
+    Returns function which gets recommended fields from Splunk for given datamodel
+
+    Note that data is being dynamically retrieved from Splunk. When CIM add-on version changes
+    retrieved data may differ
+
+    Args:
+        splunk_search_util: Other fixture preparing connection to Splunk Search.
+
+    """
     recommended_fields = defaultdict(list)
 
     def _find(name, dictionary):

--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -820,16 +820,26 @@ def splunk_dm_recommended_fields(splunk_search_util):
     def update_recommended_fields(model, datasets):
         model_key = f"{model}:{':'.join(datasets)}".strip(":")
         if model_key not in recommended_fields:
-            for cim_model in splunk_search_util.getFieldValuesList(f'| rest /servicesNS/-/-/data/models/{model} | fields "eai:data"'):
+            for cim_model in splunk_search_util.getFieldValuesList(
+                f'| rest /servicesNS/-/-/data/models/{model} | fields "eai:data"'
+            ):
                 model_definition = json.loads(cim_model["eai:data"])
                 for object in model_definition["objects"]:
                     object_name = object["objectName"]
-                    if object["parentName"] == "BaseEvent" or object_name in datasets or object_name == model:
-                        for fields in chain(_find("fields", object), _find("outputFields", object)):
+                    if (
+                        object["parentName"] == "BaseEvent"
+                        or object_name in datasets
+                        or object_name == model
+                    ):
+                        for fields in chain(
+                            _find("fields", object), _find("outputFields", object)
+                        ):
                             for field in fields:
                                 recommended = field["comment"].get("recommended")
                                 if recommended:
-                                    recommended_fields[model_key].append(field["fieldName"])
+                                    recommended_fields[model_key].append(
+                                        field["fieldName"]
+                                    )
 
         return recommended_fields
 

--- a/pytest_splunk_addon/standard_lib/app_test_generator.py
+++ b/pytest_splunk_addon/standard_lib/app_test_generator.py
@@ -81,13 +81,10 @@ class AppTestGenerator(object):
             fixture(str): fixture name
         """
         store_events = self.pytest_config.getoption("store_events")
-        if fixture.startswith("splunk_searchtime_fields") or fixture.startswith(
-            "splunk_indextime"
-        ):
-            config_path = self.pytest_config.getoption("splunk_data_generator")
-            sample_generator = SampleXdistGenerator(
-                self.pytest_config.getoption("splunk_app"), config_path
-            )
+        config_path = self.pytest_config.getoption("splunk_data_generator")
+        sample_generator = SampleXdistGenerator(
+            self.pytest_config.getoption("splunk_app"), config_path
+        )
         if fixture.startswith("splunk_searchtime_fields"):
             yield from self.dedup_tests(
                 self.fieldtest_generator.generate_tests(
@@ -97,7 +94,7 @@ class AppTestGenerator(object):
             )
         elif fixture.startswith("splunk_searchtime_cim"):
             yield from self.dedup_tests(
-                self.cim_test_generator.generate_tests(fixture), fixture
+                self.cim_test_generator.generate_tests(fixture, sample_generator, store_events), fixture
             )
         # elif fixture.startswith("splunk_searchtime_requirement"):
         #     if self.pytest_config.getoption("requirement_test") != "None":

--- a/pytest_splunk_addon/standard_lib/app_test_generator.py
+++ b/pytest_splunk_addon/standard_lib/app_test_generator.py
@@ -94,7 +94,10 @@ class AppTestGenerator(object):
             )
         elif fixture.startswith("splunk_searchtime_cim"):
             yield from self.dedup_tests(
-                self.cim_test_generator.generate_tests(fixture, sample_generator, store_events), fixture
+                self.cim_test_generator.generate_tests(
+                    fixture, sample_generator, store_events
+                ),
+                fixture,
             )
         # elif fixture.startswith("splunk_searchtime_requirement"):
         #     if self.pytest_config.getoption("requirement_test") != "None":

--- a/pytest_splunk_addon/standard_lib/cim_tests/test_generator.py
+++ b/pytest_splunk_addon/standard_lib/cim_tests/test_generator.py
@@ -277,5 +277,5 @@ class CIMTestGenerator(object):
 
                 yield pytest.param(
                     {"datamodel": model, "datasets": datasets, "fields": fields},
-                    id=f"{model}-{datasets}::sample_name::{event.sample_name}::host::{event.metadata.get('host')}",
+                    id=f"{model}-{'-'.join(datasets)}::sample_name::{event.sample_name}::host::{event.metadata.get('host')}",
                 )

--- a/pytest_splunk_addon/standard_lib/cim_tests/test_generator.py
+++ b/pytest_splunk_addon/standard_lib/cim_tests/test_generator.py
@@ -46,11 +46,11 @@ class CIMTestGenerator(object):
     COMMON_FIELDS_PATH = "CommonFields.json"
 
     def __init__(
-            self,
-            addon_path,
-            data_model_path,
-            test_field_type=["required", "conditional"],
-            common_fields_path=None,
+        self,
+        addon_path,
+        data_model_path,
+        test_field_type=["required", "conditional"],
+        common_fields_path=None,
     ):
 
         self.data_model_handler = DataModelHandler(data_model_path)
@@ -163,8 +163,8 @@ class CIMTestGenerator(object):
                     each_field
                     for each_field in test_dataset.fields
                     if each_field.type
-                       in ["not_allowed_in_search_and_props", "not_allowed_in_props"]
-                       and each_field not in common_fields_list
+                    in ["not_allowed_in_search_and_props", "not_allowed_in_props"]
+                    and each_field not in common_fields_list
                 ]
             )
 
@@ -182,7 +182,7 @@ class CIMTestGenerator(object):
                     for each in test_group["fields"]
                     for each_common_field in common_fields_list
                     if each_common_field.name == each.name
-                       and each_common_field not in not_allowed_fields
+                    and each_common_field not in not_allowed_fields
                 ]
             )
 
@@ -216,8 +216,8 @@ class CIMTestGenerator(object):
                     each_field
                     for each_field in test_dataset.fields
                     if each_field.type
-                       in ["not_allowed_in_search_and_props", "not_allowed_in_search"]
-                       and each_field not in test_fields
+                    in ["not_allowed_in_search_and_props", "not_allowed_in_search"]
+                    and each_field not in test_fields
                 ]
             )
             yield pytest.param(
@@ -268,16 +268,14 @@ class CIMTestGenerator(object):
                 if datasets:
                     datasets = [dataset.replace(" ", "_") for dataset in datasets]
 
-                fields = list(event.requirement_test_data["cim_fields"].keys()) + event.requirement_test_data[
-                    "missing_recommended_fields"]
+                fields = (
+                    list(event.requirement_test_data["cim_fields"].keys())
+                    + event.requirement_test_data["missing_recommended_fields"]
+                )
                 for exception in event.requirement_test_data["exceptions"]:
                     fields.append(exception["name"])
 
                 yield pytest.param(
-                    {
-                        "datamodel": model,
-                        "datasets": datasets,
-                        "fields": fields
-                    },
+                    {"datamodel": model, "datasets": datasets, "fields": fields},
                     id=f"{model}-{datasets}::sample_name::{event.sample_name}::host::{event.metadata.get('host')}",
                 )

--- a/pytest_splunk_addon/standard_lib/cim_tests/test_generator.py
+++ b/pytest_splunk_addon/standard_lib/cim_tests/test_generator.py
@@ -49,18 +49,20 @@ class CIMTestGenerator(object):
         self,
         addon_path,
         data_model_path,
+        tokenized_events,
         test_field_type=["required", "conditional"],
         common_fields_path=None,
     ):
 
         self.data_model_handler = DataModelHandler(data_model_path)
         self.addon_parser = AddonParser(addon_path)
+        self.tokenized_events = tokenized_events
         self.test_field_type = test_field_type
         self.common_fields_path = common_fields_path or op.join(
             op.dirname(op.abspath(__file__)), self.COMMON_FIELDS_PATH
         )
 
-    def generate_tests(self, fixture, sample_generator, store_events):
+    def generate_tests(self, fixture):
         """
         Generate the test cases based on the fixture provided
         supported fixtures:
@@ -82,9 +84,7 @@ class CIMTestGenerator(object):
         elif fixture.endswith("mapped_datamodel"):
             yield from self.generate_mapped_datamodel_tests()
         elif fixture.endswith("fields_recommended"):
-            store_sample = sample_generator.get_samples(store_events)
-            tokenized_events = store_sample.get("tokenized_events")
-            yield from self.generate_recommended_fields_tests(tokenized_events)
+            yield from self.generate_recommended_fields_tests()
 
     def get_mapped_datasets(self):
         """
@@ -258,8 +258,8 @@ class CIMTestGenerator(object):
             id=f"mapped_datamodel_tests",
         )
 
-    def generate_recommended_fields_tests(self, tokenized_events):
-        for event in tokenized_events:
+    def generate_recommended_fields_tests(self):
+        for event in self.tokenized_events:
             if not event.requirement_test_data:
                 continue
             for _, datamodel in event.requirement_test_data["datamodels"].items():

--- a/pytest_splunk_addon/standard_lib/cim_tests/test_generator.py
+++ b/pytest_splunk_addon/standard_lib/cim_tests/test_generator.py
@@ -46,11 +46,11 @@ class CIMTestGenerator(object):
     COMMON_FIELDS_PATH = "CommonFields.json"
 
     def __init__(
-        self,
-        addon_path,
-        data_model_path,
-        test_field_type=["required", "conditional"],
-        common_fields_path=None,
+            self,
+            addon_path,
+            data_model_path,
+            test_field_type=["required", "conditional"],
+            common_fields_path=None,
     ):
 
         self.data_model_handler = DataModelHandler(data_model_path)
@@ -60,7 +60,7 @@ class CIMTestGenerator(object):
             op.dirname(op.abspath(__file__)), self.COMMON_FIELDS_PATH
         )
 
-    def generate_tests(self, fixture):
+    def generate_tests(self, fixture, sample_generator, store_events):
         """
         Generate the test cases based on the fixture provided
         supported fixtures:
@@ -72,6 +72,7 @@ class CIMTestGenerator(object):
         Args:
             fixture(str): fixture name
         """
+
         if fixture.endswith("fields"):
             yield from self.generate_cim_fields_tests()
         elif fixture.endswith("not_allowed_in_props"):
@@ -80,6 +81,10 @@ class CIMTestGenerator(object):
             yield from self.generate_fields_event_count_test()
         elif fixture.endswith("mapped_datamodel"):
             yield from self.generate_mapped_datamodel_tests()
+        elif fixture.endswith("fields_recommended"):
+            store_sample = sample_generator.get_samples(store_events)
+            tokenized_events = store_sample.get("tokenized_events")
+            yield from self.generate_recommended_fields_tests(tokenized_events)
 
     def get_mapped_datasets(self):
         """
@@ -158,8 +163,8 @@ class CIMTestGenerator(object):
                     each_field
                     for each_field in test_dataset.fields
                     if each_field.type
-                    in ["not_allowed_in_search_and_props", "not_allowed_in_props"]
-                    and each_field not in common_fields_list
+                       in ["not_allowed_in_search_and_props", "not_allowed_in_props"]
+                       and each_field not in common_fields_list
                 ]
             )
 
@@ -177,7 +182,7 @@ class CIMTestGenerator(object):
                     for each in test_group["fields"]
                     for each_common_field in common_fields_list
                     if each_common_field.name == each.name
-                    and each_common_field not in not_allowed_fields
+                       and each_common_field not in not_allowed_fields
                 ]
             )
 
@@ -211,8 +216,8 @@ class CIMTestGenerator(object):
                     each_field
                     for each_field in test_dataset.fields
                     if each_field.type
-                    in ["not_allowed_in_search_and_props", "not_allowed_in_search"]
-                    and each_field not in test_fields
+                       in ["not_allowed_in_search_and_props", "not_allowed_in_search"]
+                       and each_field not in test_fields
                 ]
             )
             yield pytest.param(
@@ -252,3 +257,27 @@ class CIMTestGenerator(object):
             {"eventtypes": eventtypes},
             id=f"mapped_datamodel_tests",
         )
+
+    def generate_recommended_fields_tests(self, tokenized_events):
+        for event in tokenized_events:
+            if not event.requirement_test_data:
+                continue
+            for _, datamodel in event.requirement_test_data["datamodels"].items():
+                model, *datasets = datamodel.split(":")
+                model = model.replace(" ", "_")
+                if datasets:
+                    datasets = [dataset.replace(" ", "_") for dataset in datasets]
+
+                fields = list(event.requirement_test_data["cim_fields"].keys()) + event.requirement_test_data[
+                    "missing_recommended_fields"]
+                for exception in event.requirement_test_data["exceptions"]:
+                    fields.append(exception["name"])
+
+                yield pytest.param(
+                    {
+                        "datamodel": model,
+                        "datasets": datasets,
+                        "fields": fields
+                    },
+                    id=f"{model}-{datasets}::sample_name::{event.sample_name}::host::{event.metadata.get('host')}",
+                )

--- a/pytest_splunk_addon/standard_lib/cim_tests/test_templates.py
+++ b/pytest_splunk_addon/standard_lib/cim_tests/test_templates.py
@@ -498,6 +498,11 @@ class CIMTestTemplates(object):
 
         model_fields = fields_from_splunk[model_key]
 
-        assert all(
-            item in set(fields) for item in set(model_fields)
-        ), f"Not all fields from datamodel - {model_fields} found for event definition {fields}"
+        missing_fields = []
+        for field in set(model_fields):
+            if field not in fields:
+                missing_fields.append(field)
+
+        assert (
+            missing_fields == []
+        ), f"Not all fields from datamodel found for event definition. Missing fields {missing_fields}"

--- a/pytest_splunk_addon/standard_lib/cim_tests/test_templates.py
+++ b/pytest_splunk_addon/standard_lib/cim_tests/test_templates.py
@@ -39,12 +39,12 @@ class CIMTestTemplates(object):
     @pytest.mark.splunk_searchtime_cim
     @pytest.mark.splunk_searchtime_cim_fields
     def test_cim_required_fields(
-        self,
-        splunk_search_util,
-        splunk_ingest_data,
-        splunk_setup,
-        splunk_searchtime_cim_fields,
-        record_property,
+            self,
+            splunk_search_util,
+            splunk_ingest_data,
+            splunk_setup,
+            splunk_searchtime_cim_fields,
+            record_property,
     ):
         """
         Test the the required fields in the data models are extracted with valid values.
@@ -65,9 +65,9 @@ class CIMTestTemplates(object):
         cim_data_model = cim_data_set[-1].data_model
         data_set = str(cim_data_set[-1])
         index_list = (
-            "(index="
-            + " OR index=".join(splunk_search_util.search_index.split(","))
-            + ")"
+                "(index="
+                + " OR index=".join(splunk_search_util.search_index.split(","))
+                + ")"
         )
 
         # Search Query
@@ -152,12 +152,12 @@ class CIMTestTemplates(object):
     @pytest.mark.splunk_searchtime_cim
     @pytest.mark.splunk_searchtime_cim_fields_not_allowed_in_search
     def test_cim_fields_not_allowed_in_search(
-        self,
-        splunk_ingest_data,
-        splunk_search_util,
-        splunk_setup,
-        splunk_searchtime_cim_fields_not_allowed_in_search,
-        record_property,
+            self,
+            splunk_ingest_data,
+            splunk_search_util,
+            splunk_setup,
+            splunk_searchtime_cim_fields_not_allowed_in_search,
+            record_property,
     ):
         """
         This test case checks the event_count for the cim fields of type ["not_allowed_in_search_and_props", "not_allowed_in_search"].
@@ -173,9 +173,9 @@ class CIMTestTemplates(object):
 
         # Search Query
         index_list = (
-            "(index="
-            + " OR index=".join(splunk_search_util.search_index.split(","))
-            + ")"
+                "(index="
+                + " OR index=".join(splunk_search_util.search_index.split(","))
+                + ")"
         )
 
         base_search = "search {}".format(index_list)
@@ -229,7 +229,7 @@ class CIMTestTemplates(object):
                 for each_elem in results
                 for field in cim_fields
                 if not each_elem.get(field.name) == "0"
-                and not each_elem.get(field.name) == each_elem["sourcetype"]
+                   and not each_elem.get(field.name) == each_elem["sourcetype"]
             ]
 
             violation_str = (
@@ -249,11 +249,11 @@ class CIMTestTemplates(object):
     @pytest.mark.splunk_searchtime_cim
     @pytest.mark.splunk_searchtime_cim_fields_not_allowed_in_props
     def test_cim_fields_not_allowed_in_props(
-        self,
-        splunk_ingest_data,
-        splunk_setup,
-        splunk_searchtime_cim_fields_not_allowed_in_props,
-        record_property,
+            self,
+            splunk_ingest_data,
+            splunk_setup,
+            splunk_searchtime_cim_fields_not_allowed_in_props,
+            record_property,
     ):
         """
         This testcase checks for cim field of type ["not_allowed_in_search_and_props", "not_allowed_in_props"] if an extraction is defined in the configuration file.
@@ -280,13 +280,13 @@ class CIMTestTemplates(object):
     @pytest.mark.splunk_searchtime_cim
     @pytest.mark.splunk_searchtime_cim_mapped_datamodel
     def test_eventtype_mapped_multiple_cim_datamodel(
-        self,
-        splunk_search_util,
-        splunk_ingest_data,
-        splunk_setup,
-        splunk_searchtime_cim_mapped_datamodel,
-        record_property,
-        caplog,
+            self,
+            splunk_search_util,
+            splunk_ingest_data,
+            splunk_setup,
+            splunk_searchtime_cim_mapped_datamodel,
+            record_property,
+            caplog,
     ):
         """
         This test case check that event type is not be mapped with more than one data model
@@ -430,9 +430,9 @@ class CIMTestTemplates(object):
             {"name": "Web", "tags": [["web"], ["web", "proxy"]]},
         ]
         index_list = (
-            "(index="
-            + " OR index=".join(splunk_search_util.search_index.split(","))
-            + ")"
+                "(index="
+                + " OR index=".join(splunk_search_util.search_index.split(","))
+                + ")"
         )
         search = "search {} ".format(index_list)
         # search = "search "
@@ -482,3 +482,19 @@ class CIMTestTemplates(object):
             f"\nQuery result greater than 0.\nsearch=\n{search} \n \n"
             f"Event type which associated with multiple data model \n{result_str}"
         )
+
+    @pytest.mark.splunk_searchtime_cim
+    @pytest.mark.splunk_requirements
+    @pytest.mark.splunk_requirements_unit
+    def test_fields_recommended(self, splunk_dm_recommended_fields, splunk_searchtime_cim_fields_recommended):
+        datamodel = splunk_searchtime_cim_fields_recommended["datamodel"]
+        datasets = splunk_searchtime_cim_fields_recommended["datasets"]
+        fields = splunk_searchtime_cim_fields_recommended["fields"]
+
+        fields_from_splunk = splunk_dm_recommended_fields(datamodel, datasets)
+        model_key = f"{datamodel}:{':'.join(datasets)}".strip(":")
+
+        model_fields = fields_from_splunk[model_key]
+
+        assert all(item in set(fields) for item in set(
+            model_fields)), f"Not all fields from datamodel - {model_fields} found for event definition {fields}"

--- a/pytest_splunk_addon/standard_lib/cim_tests/test_templates.py
+++ b/pytest_splunk_addon/standard_lib/cim_tests/test_templates.py
@@ -486,7 +486,7 @@ class CIMTestTemplates(object):
     @pytest.mark.splunk_searchtime_cim
     @pytest.mark.splunk_requirements
     @pytest.mark.splunk_requirements_unit
-    def test_fields_recommended(
+    def test_cim_fields_recommended(
         self, splunk_dm_recommended_fields, splunk_searchtime_cim_fields_recommended
     ):
         datamodel = splunk_searchtime_cim_fields_recommended["datamodel"]

--- a/pytest_splunk_addon/standard_lib/cim_tests/test_templates.py
+++ b/pytest_splunk_addon/standard_lib/cim_tests/test_templates.py
@@ -39,12 +39,12 @@ class CIMTestTemplates(object):
     @pytest.mark.splunk_searchtime_cim
     @pytest.mark.splunk_searchtime_cim_fields
     def test_cim_required_fields(
-            self,
-            splunk_search_util,
-            splunk_ingest_data,
-            splunk_setup,
-            splunk_searchtime_cim_fields,
-            record_property,
+        self,
+        splunk_search_util,
+        splunk_ingest_data,
+        splunk_setup,
+        splunk_searchtime_cim_fields,
+        record_property,
     ):
         """
         Test the the required fields in the data models are extracted with valid values.
@@ -65,9 +65,9 @@ class CIMTestTemplates(object):
         cim_data_model = cim_data_set[-1].data_model
         data_set = str(cim_data_set[-1])
         index_list = (
-                "(index="
-                + " OR index=".join(splunk_search_util.search_index.split(","))
-                + ")"
+            "(index="
+            + " OR index=".join(splunk_search_util.search_index.split(","))
+            + ")"
         )
 
         # Search Query
@@ -152,12 +152,12 @@ class CIMTestTemplates(object):
     @pytest.mark.splunk_searchtime_cim
     @pytest.mark.splunk_searchtime_cim_fields_not_allowed_in_search
     def test_cim_fields_not_allowed_in_search(
-            self,
-            splunk_ingest_data,
-            splunk_search_util,
-            splunk_setup,
-            splunk_searchtime_cim_fields_not_allowed_in_search,
-            record_property,
+        self,
+        splunk_ingest_data,
+        splunk_search_util,
+        splunk_setup,
+        splunk_searchtime_cim_fields_not_allowed_in_search,
+        record_property,
     ):
         """
         This test case checks the event_count for the cim fields of type ["not_allowed_in_search_and_props", "not_allowed_in_search"].
@@ -173,9 +173,9 @@ class CIMTestTemplates(object):
 
         # Search Query
         index_list = (
-                "(index="
-                + " OR index=".join(splunk_search_util.search_index.split(","))
-                + ")"
+            "(index="
+            + " OR index=".join(splunk_search_util.search_index.split(","))
+            + ")"
         )
 
         base_search = "search {}".format(index_list)
@@ -229,7 +229,7 @@ class CIMTestTemplates(object):
                 for each_elem in results
                 for field in cim_fields
                 if not each_elem.get(field.name) == "0"
-                   and not each_elem.get(field.name) == each_elem["sourcetype"]
+                and not each_elem.get(field.name) == each_elem["sourcetype"]
             ]
 
             violation_str = (
@@ -249,11 +249,11 @@ class CIMTestTemplates(object):
     @pytest.mark.splunk_searchtime_cim
     @pytest.mark.splunk_searchtime_cim_fields_not_allowed_in_props
     def test_cim_fields_not_allowed_in_props(
-            self,
-            splunk_ingest_data,
-            splunk_setup,
-            splunk_searchtime_cim_fields_not_allowed_in_props,
-            record_property,
+        self,
+        splunk_ingest_data,
+        splunk_setup,
+        splunk_searchtime_cim_fields_not_allowed_in_props,
+        record_property,
     ):
         """
         This testcase checks for cim field of type ["not_allowed_in_search_and_props", "not_allowed_in_props"] if an extraction is defined in the configuration file.
@@ -280,13 +280,13 @@ class CIMTestTemplates(object):
     @pytest.mark.splunk_searchtime_cim
     @pytest.mark.splunk_searchtime_cim_mapped_datamodel
     def test_eventtype_mapped_multiple_cim_datamodel(
-            self,
-            splunk_search_util,
-            splunk_ingest_data,
-            splunk_setup,
-            splunk_searchtime_cim_mapped_datamodel,
-            record_property,
-            caplog,
+        self,
+        splunk_search_util,
+        splunk_ingest_data,
+        splunk_setup,
+        splunk_searchtime_cim_mapped_datamodel,
+        record_property,
+        caplog,
     ):
         """
         This test case check that event type is not be mapped with more than one data model
@@ -430,9 +430,9 @@ class CIMTestTemplates(object):
             {"name": "Web", "tags": [["web"], ["web", "proxy"]]},
         ]
         index_list = (
-                "(index="
-                + " OR index=".join(splunk_search_util.search_index.split(","))
-                + ")"
+            "(index="
+            + " OR index=".join(splunk_search_util.search_index.split(","))
+            + ")"
         )
         search = "search {} ".format(index_list)
         # search = "search "
@@ -486,7 +486,9 @@ class CIMTestTemplates(object):
     @pytest.mark.splunk_searchtime_cim
     @pytest.mark.splunk_requirements
     @pytest.mark.splunk_requirements_unit
-    def test_fields_recommended(self, splunk_dm_recommended_fields, splunk_searchtime_cim_fields_recommended):
+    def test_fields_recommended(
+        self, splunk_dm_recommended_fields, splunk_searchtime_cim_fields_recommended
+    ):
         datamodel = splunk_searchtime_cim_fields_recommended["datamodel"]
         datasets = splunk_searchtime_cim_fields_recommended["datasets"]
         fields = splunk_searchtime_cim_fields_recommended["fields"]
@@ -496,5 +498,6 @@ class CIMTestTemplates(object):
 
         model_fields = fields_from_splunk[model_key]
 
-        assert all(item in set(fields) for item in set(
-            model_fields)), f"Not all fields from datamodel - {model_fields} found for event definition {fields}"
+        assert all(
+            item in set(fields) for item in set(model_fields)
+        ), f"Not all fields from datamodel - {model_fields} found for event definition {fields}"

--- a/pytest_splunk_addon/standard_lib/index_tests/test_generator.py
+++ b/pytest_splunk_addon/standard_lib/index_tests/test_generator.py
@@ -16,7 +16,7 @@
 import logging
 import pytest
 
-# from ..sample_generation import SampleXdistGenerator
+from ..sample_generation import SampleGenerator
 from ..sample_generation.rule import raise_warning
 from ..sample_generation.sample_event import SampleEvent
 
@@ -32,7 +32,10 @@ class IndexTimeTestGenerator(object):
       for the Add-on.
     """
 
-    def generate_tests(self, store_events, sample_generator, test_type):
+    def __init__(self, tokenized_events):
+        self.tokenized_events = tokenized_events
+
+    def generate_tests(self, test_type):
         """
         Generates the test cases based on test_type
 
@@ -45,10 +48,7 @@ class IndexTimeTestGenerator(object):
             pytest.params for the test templates
 
         """
-        # sample_generator = SampleXdistGenerator(app_path, config_path)
-        store_sample = sample_generator.get_samples(store_events)
-        tokenized_events = store_sample.get("tokenized_events")
-        if not store_sample.get("conf_name") == "psa-data-gen":
+        if not SampleGenerator.conf_name == "psa-data-gen":
             msg = (
                 "Index time tests cannot be executed without "
                 "pytest-splunk-addon-data.conf"
@@ -58,11 +58,11 @@ class IndexTimeTestGenerator(object):
 
         if test_type == "line_breaker":
             LOGGER.info("Generating line breaker test")
-            yield from self.generate_line_breaker_tests(tokenized_events)
+            yield from self.generate_line_breaker_tests()
 
         else:
 
-            for tokenized_event in tokenized_events:
+            for tokenized_event in self.tokenized_events:
 
                 identifier_key = tokenized_event.metadata.get("identifier")
 
@@ -99,12 +99,9 @@ class IndexTimeTestGenerator(object):
                         tokenized_event, identifier_key, hosts
                     )
 
-    def generate_line_breaker_tests(self, tokenized_events):
+    def generate_line_breaker_tests(self):
         """
         Generates test case for testing line breaker
-
-        Args:
-            tokenized_events (list): List of tokenized events
 
         Yields:
             pytest.params for the test templates
@@ -117,7 +114,7 @@ class IndexTimeTestGenerator(object):
         # As all the sample events would have same properties except Host
         # Assigning those values outside the loop
 
-        for event in tokenized_events:
+        for event in self.tokenized_events:
             try:
                 sample_count = int(event.metadata.get("sample_count", 1))
                 expected_count = int(event.metadata.get("expected_event_count", 1))

--- a/pytest_splunk_addon/standard_lib/sample_generation/pytest_splunk_addon_data_parser.py
+++ b/pytest_splunk_addon/standard_lib/sample_generation/pytest_splunk_addon_data_parser.py
@@ -131,12 +131,18 @@ class PytestSplunkAddonDataParser:
         schema = XMLSchema(SCHEMA_PATH)
         if os.path.exists(self._path_to_samples):
             for sample_file in os.listdir(self._path_to_samples):
-                if sample_file.endswith(".xml") or sample_file.endswith(".log"):
-                    schema.validate(os.path.join(self._path_to_samples, sample_file))
                 for stanza, fields in sorted(self.psa_data.items()):
                     stanza_match_obj = re.search(stanza, sample_file)
                     if stanza_match_obj and stanza_match_obj.group(0) == sample_file:
                         self.match_stanzas.add(stanza)
+                        if (
+                            "requirement_test_sample" in self.psa_data[stanza].keys()
+                            and int(self.psa_data[stanza]["requirement_test_sample"])
+                            > 0
+                        ):
+                            schema.validate(
+                                os.path.join(self._path_to_samples, sample_file)
+                            )
                         psa_data_dict.setdefault(sample_file, {"tokens": {}})
                         for key, value in fields.items():
                             if key.startswith("token"):

--- a/pytest_splunk_addon/standard_lib/sample_generation/pytest_splunk_addon_data_parser.py
+++ b/pytest_splunk_addon/standard_lib/sample_generation/pytest_splunk_addon_data_parser.py
@@ -45,9 +45,9 @@ class PytestSplunkAddonDataParser:
         self._psa_data = None
         self.addon_path = addon_path
         self.match_stanzas = set()
-        self._path_to_samples = self._path_to_samples()
+        self._path_to_samples = self._get_path_to_samples()
 
-    def _path_to_samples(self):
+    def _get_path_to_samples(self):
         if os.path.exists(os.path.join(self.config_path, "samples")):
             LOGGER.info(
                 "Samples path is: {}".format(os.path.join(self.config_path, "samples"))

--- a/pytest_splunk_addon/standard_lib/sample_generation/schema.xsd
+++ b/pytest_splunk_addon/standard_lib/sample_generation/schema.xsd
@@ -1,0 +1,199 @@
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="device">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element type="xs:string" name="vendor"/>
+        <xs:element type="xs:string" name="product"/>
+        <xs:element name="version"  maxOccurs="unbounded" minOccurs="1">
+          <xs:complexType>
+            <xs:simpleContent>
+              <xs:extension base="xs:string">
+                <xs:attribute name="id" use="required">
+                  <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                    <xs:minLength value="1"/>
+                    </xs:restriction>
+                </xs:simpleType>
+                </xs:attribute>
+                <xs:attribute type="xs:string" name="os" use="optional" />
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="event" maxOccurs="unbounded" minOccurs="1">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="version"  maxOccurs="unbounded" minOccurs="0">
+                <xs:complexType>
+                  <xs:simpleContent>
+                    <xs:extension base="xs:string">
+                      <xs:attribute type="xs:string" name="id"/>
+                    </xs:extension>
+                  </xs:simpleContent>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="transport">
+                <xs:complexType>
+                  <xs:attribute name="type" use="required">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:string">
+                        <xs:enumeration value="dbx"/>
+                        <xs:enumeration value="forwarder"/>
+                        <xs:enumeration value="modinput"/>
+                        <xs:enumeration value="Mod input"/>
+                        <xs:enumeration value="Modular Input"/>
+                        <xs:enumeration value="Modular input"/>
+                        <xs:enumeration value="modular input"/>
+                        <xs:enumeration value="modular_input"/>
+                        <xs:enumeration value="Mod Input"/>
+                        <xs:enumeration value="scripted input"/>
+                        <xs:enumeration value="Scripted Input"/>
+                        <xs:enumeration value="scripted_input"/>
+                        <xs:enumeration value="Scripted inputs"/>
+                        <xs:enumeration value="scripted inputs"/>
+                        <xs:enumeration value="Syslog"/>
+                        <xs:enumeration value="syslog"/>
+                        <xs:enumeration value="windows_input"/>
+                        <xs:enumeration value="hec_raw"/>
+                        <xs:enumeration value="hec_event"/>
+                        <xs:enumeration value="file_monitor"/>
+                        <xs:enumeration value="file_monitor_w3c"/>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>
+                  <xs:attribute type="xs:string" name="name" use="optional"/>
+                  <xs:attribute name="host" type="xs:string" use="optional"/>
+                  <xs:attribute name="source" type="xs:string" use="optional"/>
+                  <xs:attribute name="sourcetype" type="xs:string" use="optional"/>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="source">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="jira" maxOccurs="unbounded" minOccurs="0">
+                      <xs:complexType>
+                        <xs:simpleContent>
+                          <xs:extension base="xs:string">
+                            <xs:attribute type="xs:string" name="id" use="required"/>
+                          </xs:extension>
+                        </xs:simpleContent>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element type="xs:string" name="comment" maxOccurs="1" minOccurs="1"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element type="xs:string" name="raw"/>
+              <xs:element name="cim">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="models" maxOccurs="1" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element type="xs:string" name="model" maxOccurs="unbounded" minOccurs="1"/>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="cim_fields" maxOccurs="1" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="field" maxOccurs="unbounded" minOccurs="1">
+                            <xs:complexType>
+                              <xs:simpleContent>
+                                <xs:extension base="xs:string">
+                                  <xs:attribute type="xs:string" name="name" use="optional"/>
+                                  <xs:attribute type="xs:string" name="value" use="optional"/>
+                                </xs:extension>
+                              </xs:simpleContent>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="missing_recommended_fields" maxOccurs="1" minOccurs="0">
+                      <xs:complexType mixed="true">
+                        <xs:sequence>
+                          <xs:element type="xs:string" name="field" maxOccurs="unbounded" minOccurs="0"/>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="exceptions" maxOccurs="1" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="field" maxOccurs="unbounded" minOccurs="1">
+                            <xs:complexType>
+                              <xs:simpleContent>
+                                <xs:extension base="xs:string">
+                                  <xs:attribute type="xs:string" name="name" use="required" />
+                                  <xs:attribute type="xs:string" name="value" use="required"/>
+                                  <xs:attribute type="xs:string" name="reason" use="required"/>
+                                </xs:extension>
+                              </xs:simpleContent>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute type="xs:string" name="version" use="optional" />
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="other_mappings" maxOccurs="1" minOccurs="0">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="field" maxOccurs="unbounded" minOccurs="1">
+                      <xs:complexType>
+                        <xs:simpleContent>
+                          <xs:extension base="xs:string">
+                            <xs:attribute type="xs:string" name="name" use="required"/>
+                            <xs:attribute type="xs:string" name="value" use="required"/>
+                          </xs:extension>
+                        </xs:simpleContent>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="test" maxOccurs="1" minOccurs="0">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="integration" minOccurs="0" maxOccurs="unbounded">
+                      <xs:complexType>
+                        <xs:sequence/>
+                        <xs:attribute name="product" type="xs:string"/>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="models" maxOccurs="1" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element type="xs:string" name="model" maxOccurs="unbounded" minOccurs="1"/>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="field" minOccurs="0" maxOccurs="unbounded">
+                      <xs:complexType>
+                        <xs:sequence/>
+                        <xs:attribute name="name" type="xs:string"/>
+                        <xs:attribute name="value" type="xs:string"/>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute type="xs:string" name="code" use="required" />
+            <xs:attribute type="xs:string" name="name" use="required"/>
+            <xs:attribute type="xs:string" name="format" use="required"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="unsupported"  maxOccurs="1" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+               <xs:element type="xs:string" name="raw" maxOccurs="unbounded" minOccurs="0"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/tests/e2e/constants.py
+++ b/tests/e2e/constants.py
@@ -249,6 +249,7 @@ TA_FICTION_PASSED = [
 
 TA_FICTION_SKIPPED = [
     "*test_splunk_app_fiction.py::Test_App::test_requirements_fields[splunk_searchtime_fields_requirements0* SKIPPED*",
+    "*test_splunk_app_cim_fiction.py::Test_App::test_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*",
 ]
 """
 Define the TA_broken add-on passed test case list.
@@ -391,6 +392,7 @@ TA_BROKEN_FAILED = [
 
 TA_BROKEN_SKIPPED = [
     "*test_splunk_app_broken.py::Test_App::test_requirements_fields[splunk_searchtime_fields_requirements0* SKIPPED*",
+    "*test_splunk_app_cim_fiction.py::Test_App::test_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*",
 ]
 
 """
@@ -426,6 +428,10 @@ TA_CIM_FICTION_PASSED = [
     '*test_splunk_app_cim_fiction.py::Test_App::test_cim_fields_not_allowed_in_search*eventtype="eventtype_splunkd_fiction_three"::Fiction_Three_Child* PASSED*',
     '*test_splunk_app_cim_fiction.py::Test_App::test_cim_fields_not_allowed_in_search*eventtype="eventtype_splunkd_fiction_two"::Fiction_Two* PASSED*',
     "*test_splunk_app_cim_fiction.py::Test_App::test_cim_fields_not_allowed_in_props*searchtime_cim_fields* PASSED*",
+]
+
+TA_CIM_FICTION_SKIPPED = [
+    "*test_splunk_app_cim_fiction.py::Test_App::test_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*"
 ]
 
 """
@@ -471,6 +477,10 @@ TA_CIM_BROKEN_FAILED = [
     '*test_splunk_app_cim_broken.py::Test_App::test_cim_required_fields*eventtype="eventtype_splunkd_broken_with_eval"::Broken_Eval::invalid_value_null_1* FAILED*',
     '*test_splunk_app_cim_broken.py::Test_App::test_cim_required_fields*eventtype="eventtype_splunkd_broken_with_eval"::Broken_Eval::invalid_value_null_2* FAILED*',
     '*test_splunk_app_cim_broken.py::Test_App::test_cim_required_fields*eventtype="eventtype_splunkd_broken_with_eval"::Broken_Eval::fail_multi_value_field* FAILED*',
+]
+
+TA_CIM_BROKEN_SKIPPED = [
+    "*test_splunk_app_cim_fiction.py::Test_App::test_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*"
 ]
 
 """
@@ -656,6 +666,7 @@ TA_FICTION_INDEXTIME_SKIPPED = [
     "*test_splunk_fiction_indextime.py::Test_App::test_tags*splunk_searchtime_fields_tags0* SKIPPED*",
     "*test_splunk_fiction_indextime.py::Test_App::test_eventtype*splunk_searchtime_fields_eventtypes0* SKIPPED*",
     "*test_splunk_fiction_indextime.py::Test_App::test_savedsearches*splunk_searchtime_fields_savedsearches0* SKIPPED*",
+    "*test_splunk_app_cim_fiction.py::Test_App::test_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*",
 ]
 """
 Define the TA_fiction_indextime_broken add-on passed test case list.
@@ -746,6 +757,7 @@ TA_FICTION_INDEXTIME_BROKEN_SKIPPED = [
     "*test_splunk_fiction_indextime_broken.py::Test_App::test_eventtype*splunk_searchtime_fields_eventtypes0* SKIPPED*",
     "*test_splunk_fiction_indextime_broken.py::Test_App::test_savedsearches*splunk_searchtime_fields_savedsearches0* SKIPPED*",
     "*test_splunk_fiction_indextime_broken.py::Test_App::test_requirements_fields[splunk_searchtime_fields_requirements0* SKIPPED*",
+    "*test_splunk_app_cim_fiction.py::Test_App::test_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*",
 ]
 """
 Define TA_requirement_tests passed test
@@ -783,67 +795,70 @@ TA_REQUIREMENTS_SCRIPTED_FAILED = [
 ]
 
 TA_REQ_TRANSITION_PASSED = [
-    "test_splunk_app_req.py::Test_App::test_events_with_untokenised_values PASSED*",
-    "test_splunk_app_req.py::Test_App::test_indextime_time[test:data:1::* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_indextime_time[test:data:1::* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_indextime_time[test:data:1::* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_indextime_line_breaker[test:data:1::sample_modinput.xml* PASSED*",
-    'test_splunk_app_req.py::Test_App::test_cim_required_fields[eventtype="test_auth"::Authentication* PASSED*',
-    'test_splunk_app_req.py::Test_App::test_cim_required_fields[eventtype="test_auth"::Authentication::action* PASSED*',
-    'test_splunk_app_req.py::Test_App::test_cim_required_fields[eventtype="test_auth"::Authentication::app* PASSED*',
-    'test_splunk_app_req.py::Test_App::test_cim_required_fields[eventtype="test_auth"::Authentication::dest* PASSED*',
-    'test_splunk_app_req.py::Test_App::test_cim_required_fields[eventtype="test_auth"::Authentication::src_user* PASSED*',
-    'test_splunk_app_req.py::Test_App::test_cim_required_fields[eventtype="test_auth"::Authentication::user* PASSED*',
-    'test_splunk_app_req.py::Test_App::test_cim_required_fields[eventtype="test_auth"::Failed_Authentication* PASSED*',
-    'test_splunk_app_req.py::Test_App::test_cim_required_fields[eventtype="test_auth"::Successful_Authentication* PASSED*',
-    'test_splunk_app_req.py::Test_App::test_cim_fields_not_allowed_in_search[eventtype="test_auth"::Authentication* PASSED*',
-    "test_splunk_app_req.py::Test_App::test_cim_fields_not_allowed_in_props[searchtime_cim_fields* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_eventtype_mapped_multiple_cim_datamodel[mapped_datamodel_tests* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_splunk_internal_errors PASSED*",
-    "test_splunk_app_req.py::Test_App::test_props_fields[test:data:1* PASSED *",
-    "test_splunk_app_req.py::Test_App::test_props_fields[test:data:1::field::action* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_props_fields[test:data:1::field::app* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_props_fields[test:data:1::field::dest* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_props_fields[test:data:1::field::host* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_props_fields[test:data:1::field::ip* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_props_fields[test:data:1::field::result* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_props_fields[test:data:1::field::src* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_props_fields[test:data:1::field::status* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_props_fields[test:data:1::field::tester* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_props_fields[test:data:1::field::user* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_requirements_fields[action-error::sample_name::sample_modinput.xml::host::* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_requirements_fields[action-failure::sample_name::sample_modinput.xml::host::* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_requirements_fields[action-success::sample_name::sample_modinput.xml::host::* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_requirements_fields[app-psa::sample_name::sample_modinput.xml::host::* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_requirements_fields[app-psa::sample_name::sample_modinput.xml::host::* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_requirements_fields[app-psa::sample_name::sample_modinput.xml::host::* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_requirements_fields[dest-*::sample_name::sample_modinput.xml::host::* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_requirements_fields[dest-*::sample_name::sample_modinput.xml::host::* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_requirements_fields[dest-*::sample_name::sample_modinput.xml::host::* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_requirements_fields[src-10.100.0.1::sample_name::sample_modinput.xml::host::* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_requirements_fields[src-10.100.0.2::sample_name::sample_modinput.xml::host::* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_requirements_fields[src-10.100.0.3::sample_name::sample_modinput.xml::host::* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_requirements_fields[status-FAIL::sample_name::sample_modinput.xml::host::* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_requirements_fields[status-OTHER::sample_name::sample_modinput.xml::host::* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_requirements_fields[status-PASS::sample_name::sample_modinput.xml::host::* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_requirements_fields[user-admin::sample_name::sample_modinput.xml::host::* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_requirements_fields[user-admin::sample_name::sample_modinput.xml::host::* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_requirements_fields[user-admin::sample_name::sample_modinput.xml::host::* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_props_fields_no_dash_not_empty[test:data:1::field::action* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_props_fields_no_dash_not_empty[test:data:1::field::app* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_props_fields_no_dash_not_empty[test:data:1::field::dest* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_props_fields_no_dash_not_empty[test:data:1::field::host* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_props_fields_no_dash_not_empty[test:data:1::field::ip* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_props_fields_no_dash_not_empty[test:data:1::field::result* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_props_fields_no_dash_not_empty[test:data:1::field::src* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_props_fields_no_dash_not_empty[test:data:1::field::status* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_props_fields_no_dash_not_empty[test:data:1::field::tester* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_props_fields_no_dash_not_empty[test:data:1::field::user* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_tags[authentication::sample_name::sample_modinput.xml::host::* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_tags[authentication::sample_name::sample_modinput.xml::host::* PASSED*",
-    "test_splunk_app_req.py::Test_App::test_tags[authentication::sample_name::sample_modinput.xml::host::* PASSED*",
-    'test_splunk_app_req.py::Test_App::test_tags[eventtype="test_auth"::tag::authentication* PASSED*',
-    "test_splunk_app_req.py::Test_App::test_eventtype[eventtype::test_auth* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_events_with_untokenised_values PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_indextime_time[test:data:1::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_indextime_time[test:data:1::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_indextime_time[test:data:1::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_indextime_line_breaker[test:data:1::sample_modinput.xml* PASSED*",
+    '*test_splunk_app_req.py::Test_App::test_cim_required_fields[eventtype="test_auth"::Authentication* PASSED*',
+    '*test_splunk_app_req.py::Test_App::test_cim_required_fields[eventtype="test_auth"::Authentication::action* PASSED*',
+    '*test_splunk_app_req.py::Test_App::test_cim_required_fields[eventtype="test_auth"::Authentication::app* PASSED*',
+    '*test_splunk_app_req.py::Test_App::test_cim_required_fields[eventtype="test_auth"::Authentication::dest* PASSED*',
+    '*test_splunk_app_req.py::Test_App::test_cim_required_fields[eventtype="test_auth"::Authentication::src_user* PASSED*',
+    '*test_splunk_app_req.py::Test_App::test_cim_required_fields[eventtype="test_auth"::Authentication::user* PASSED*',
+    '*test_splunk_app_req.py::Test_App::test_cim_required_fields[eventtype="test_auth"::Failed_Authentication* PASSED*',
+    '*test_splunk_app_req.py::Test_App::test_cim_required_fields[eventtype="test_auth"::Successful_Authentication* PASSED*',
+    '*test_splunk_app_req.py::Test_App::test_cim_fields_not_allowed_in_search[eventtype="test_auth"::Authentication* PASSED*',
+    "*test_splunk_app_req.py::Test_App::test_cim_fields_not_allowed_in_props[searchtime_cim_fields* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_eventtype_mapped_multiple_cim_datamodel[mapped_datamodel_tests* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_fields_recommended[Authentication-[]::sample_name::sample_modinput.xml::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_fields_recommended[Authentication-[]::sample_name::sample_modinput.xml::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_fields_recommended[Authentication-[]::sample_name::sample_modinput.xml::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_splunk_internal_errors PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_props_fields[test:data:1* PASSED *",
+    "*test_splunk_app_req.py::Test_App::test_props_fields[test:data:1::field::action* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_props_fields[test:data:1::field::app* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_props_fields[test:data:1::field::dest* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_props_fields[test:data:1::field::host* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_props_fields[test:data:1::field::ip* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_props_fields[test:data:1::field::result* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_props_fields[test:data:1::field::src* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_props_fields[test:data:1::field::status* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_props_fields[test:data:1::field::tester* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_props_fields[test:data:1::field::user* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_requirements_fields[action-error::sample_name::sample_modinput.xml::host::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_requirements_fields[action-failure::sample_name::sample_modinput.xml::host::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_requirements_fields[action-success::sample_name::sample_modinput.xml::host::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_requirements_fields[app-psa::sample_name::sample_modinput.xml::host::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_requirements_fields[app-psa::sample_name::sample_modinput.xml::host::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_requirements_fields[app-psa::sample_name::sample_modinput.xml::host::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_requirements_fields[dest-*::sample_name::sample_modinput.xml::host::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_requirements_fields[dest-*::sample_name::sample_modinput.xml::host::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_requirements_fields[dest-*::sample_name::sample_modinput.xml::host::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_requirements_fields[src-10.100.0.1::sample_name::sample_modinput.xml::host::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_requirements_fields[src-10.100.0.2::sample_name::sample_modinput.xml::host::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_requirements_fields[src-10.100.0.3::sample_name::sample_modinput.xml::host::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_requirements_fields[status-FAIL::sample_name::sample_modinput.xml::host::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_requirements_fields[status-OTHER::sample_name::sample_modinput.xml::host::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_requirements_fields[status-PASS::sample_name::sample_modinput.xml::host::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_requirements_fields[user-admin::sample_name::sample_modinput.xml::host::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_requirements_fields[user-admin::sample_name::sample_modinput.xml::host::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_requirements_fields[user-admin::sample_name::sample_modinput.xml::host::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_props_fields_no_dash_not_empty[test:data:1::field::action* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_props_fields_no_dash_not_empty[test:data:1::field::app* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_props_fields_no_dash_not_empty[test:data:1::field::dest* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_props_fields_no_dash_not_empty[test:data:1::field::host* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_props_fields_no_dash_not_empty[test:data:1::field::ip* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_props_fields_no_dash_not_empty[test:data:1::field::result* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_props_fields_no_dash_not_empty[test:data:1::field::src* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_props_fields_no_dash_not_empty[test:data:1::field::status* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_props_fields_no_dash_not_empty[test:data:1::field::tester* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_props_fields_no_dash_not_empty[test:data:1::field::user* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_tags[authentication::sample_name::sample_modinput.xml::host::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_tags[authentication::sample_name::sample_modinput.xml::host::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_tags[authentication::sample_name::sample_modinput.xml::host::* PASSED*",
+    '*test_splunk_app_req.py::Test_App::test_tags[eventtype="test_auth"::tag::authentication* PASSED*',
+    "*test_splunk_app_req.py::Test_App::test_eventtype[eventtype::test_auth* PASSED*",
 ]
 
 TA_REQ_TRANSITION_SKIPPED = [

--- a/tests/e2e/constants.py
+++ b/tests/e2e/constants.py
@@ -392,7 +392,7 @@ TA_BROKEN_FAILED = [
 
 TA_BROKEN_SKIPPED = [
     "*test_splunk_app_broken.py::Test_App::test_requirements_fields[splunk_searchtime_fields_requirements0* SKIPPED*",
-    "*test_splunk_app_broken.py::Test_App::test_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*",
+    "*test_splunk_app_broken.py::Test_App::test_cim_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*",
 ]
 
 """
@@ -431,7 +431,7 @@ TA_CIM_FICTION_PASSED = [
 ]
 
 TA_CIM_FICTION_SKIPPED = [
-    "*test_splunk_app_cim_fiction.py::Test_App::test_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*"
+    "*test_splunk_app_cim_fiction.py::Test_App::test_cim_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*"
 ]
 
 """
@@ -662,7 +662,7 @@ TA_FICTION_INDEXTIME_SKIPPED = [
     "*test_splunk_fiction_indextime.py::Test_App::test_tags*splunk_searchtime_fields_tags0* SKIPPED*",
     "*test_splunk_fiction_indextime.py::Test_App::test_eventtype*splunk_searchtime_fields_eventtypes0* SKIPPED*",
     "*test_splunk_fiction_indextime.py::Test_App::test_savedsearches*splunk_searchtime_fields_savedsearches0* SKIPPED*",
-    "*test_splunk_fiction_indextime.py::Test_App::test_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*",
+    "*test_splunk_fiction_indextime.py::Test_App::test_cim_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*",
 ]
 """
 Define the TA_fiction_indextime_broken add-on passed test case list.
@@ -753,7 +753,7 @@ TA_FICTION_INDEXTIME_BROKEN_SKIPPED = [
     "*test_splunk_fiction_indextime_broken.py::Test_App::test_eventtype*splunk_searchtime_fields_eventtypes0* SKIPPED*",
     "*test_splunk_fiction_indextime_broken.py::Test_App::test_savedsearches*splunk_searchtime_fields_savedsearches0* SKIPPED*",
     "*test_splunk_fiction_indextime_broken.py::Test_App::test_requirements_fields[splunk_searchtime_fields_requirements0* SKIPPED*",
-    "*test_splunk_fiction_indextime_broken.py::Test_App::test_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*",
+    "*test_splunk_fiction_indextime_broken.py::Test_App::test_cim_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*",
 ]
 """
 Define TA_requirement_tests passed test
@@ -807,9 +807,9 @@ TA_REQ_TRANSITION_PASSED = [
     '*test_splunk_app_req.py::Test_App::test_cim_fields_not_allowed_in_search[eventtype="test_auth"::Authentication* PASSED*',
     "*test_splunk_app_req.py::Test_App::test_cim_fields_not_allowed_in_props[searchtime_cim_fields* PASSED*",
     "*test_splunk_app_req.py::Test_App::test_eventtype_mapped_multiple_cim_datamodel[mapped_datamodel_tests* PASSED*",
-    "*test_splunk_app_req.py::Test_App::test_fields_recommended[Authentication-*::sample_name::sample_modinput.xml::* PASSED*",
-    "*test_splunk_app_req.py::Test_App::test_fields_recommended[Authentication-*::sample_name::sample_modinput.xml::* PASSED*",
-    "*test_splunk_app_req.py::Test_App::test_fields_recommended[Authentication-*::sample_name::sample_modinput.xml::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_cim_fields_recommended[Authentication-*::sample_name::sample_modinput.xml::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_cim_fields_recommended[Authentication-*::sample_name::sample_modinput.xml::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_cim_fields_recommended[Authentication-*::sample_name::sample_modinput.xml::* PASSED*",
     "*test_splunk_app_req.py::Test_App::test_splunk_internal_errors PASSED*",
     "*test_splunk_app_req.py::Test_App::test_props_fields[test:data:1* PASSED *",
     "*test_splunk_app_req.py::Test_App::test_props_fields[test:data:1::field::action* PASSED*",

--- a/tests/e2e/constants.py
+++ b/tests/e2e/constants.py
@@ -249,8 +249,8 @@ TA_FICTION_PASSED = [
 
 TA_FICTION_SKIPPED = [
     "*test_splunk_app_fiction.py::Test_App::test_requirements_fields[splunk_searchtime_fields_requirements0* SKIPPED*",
-    "*test_splunk_app_fiction.py::Test_App::test_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*",
 ]
+
 """
 Define the TA_broken add-on passed test case list.
 """
@@ -811,9 +811,9 @@ TA_REQ_TRANSITION_PASSED = [
     '*test_splunk_app_req.py::Test_App::test_cim_fields_not_allowed_in_search[eventtype="test_auth"::Authentication* PASSED*',
     "*test_splunk_app_req.py::Test_App::test_cim_fields_not_allowed_in_props[searchtime_cim_fields* PASSED*",
     "*test_splunk_app_req.py::Test_App::test_eventtype_mapped_multiple_cim_datamodel[mapped_datamodel_tests* PASSED*",
-    "*test_splunk_app_req.py::Test_App::test_fields_recommended[Authentication-[]::sample_name::sample_modinput.xml::* PASSED*",
-    "*test_splunk_app_req.py::Test_App::test_fields_recommended[Authentication-[]::sample_name::sample_modinput.xml::* PASSED*",
-    "*test_splunk_app_req.py::Test_App::test_fields_recommended[Authentication-[]::sample_name::sample_modinput.xml::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_fields_recommended[Authentication-*::sample_name::sample_modinput.xml::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_fields_recommended[Authentication-*::sample_name::sample_modinput.xml::* PASSED*",
+    "*test_splunk_app_req.py::Test_App::test_fields_recommended[Authentication-*::sample_name::sample_modinput.xml::* PASSED*",
     "*test_splunk_app_req.py::Test_App::test_splunk_internal_errors PASSED*",
     "*test_splunk_app_req.py::Test_App::test_props_fields[test:data:1* PASSED *",
     "*test_splunk_app_req.py::Test_App::test_props_fields[test:data:1::field::action* PASSED*",

--- a/tests/e2e/constants.py
+++ b/tests/e2e/constants.py
@@ -249,7 +249,7 @@ TA_FICTION_PASSED = [
 
 TA_FICTION_SKIPPED = [
     "*test_splunk_app_fiction.py::Test_App::test_requirements_fields[splunk_searchtime_fields_requirements0* SKIPPED*",
-    "*test_splunk_app_cim_fiction.py::Test_App::test_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*",
+    "*test_splunk_app_fiction.py::Test_App::test_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*",
 ]
 """
 Define the TA_broken add-on passed test case list.
@@ -392,7 +392,7 @@ TA_BROKEN_FAILED = [
 
 TA_BROKEN_SKIPPED = [
     "*test_splunk_app_broken.py::Test_App::test_requirements_fields[splunk_searchtime_fields_requirements0* SKIPPED*",
-    "*test_splunk_app_cim_fiction.py::Test_App::test_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*",
+    "*test_splunk_app_broken.py::Test_App::test_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*",
 ]
 
 """
@@ -480,7 +480,7 @@ TA_CIM_BROKEN_FAILED = [
 ]
 
 TA_CIM_BROKEN_SKIPPED = [
-    "*test_splunk_app_cim_fiction.py::Test_App::test_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*"
+    "*test_splunk_app_cim_broken.py::Test_App::test_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*"
 ]
 
 """
@@ -666,7 +666,7 @@ TA_FICTION_INDEXTIME_SKIPPED = [
     "*test_splunk_fiction_indextime.py::Test_App::test_tags*splunk_searchtime_fields_tags0* SKIPPED*",
     "*test_splunk_fiction_indextime.py::Test_App::test_eventtype*splunk_searchtime_fields_eventtypes0* SKIPPED*",
     "*test_splunk_fiction_indextime.py::Test_App::test_savedsearches*splunk_searchtime_fields_savedsearches0* SKIPPED*",
-    "*test_splunk_app_cim_fiction.py::Test_App::test_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*",
+    "*test_splunk_fiction_indextime.py::Test_App::test_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*",
 ]
 """
 Define the TA_fiction_indextime_broken add-on passed test case list.
@@ -757,7 +757,7 @@ TA_FICTION_INDEXTIME_BROKEN_SKIPPED = [
     "*test_splunk_fiction_indextime_broken.py::Test_App::test_eventtype*splunk_searchtime_fields_eventtypes0* SKIPPED*",
     "*test_splunk_fiction_indextime_broken.py::Test_App::test_savedsearches*splunk_searchtime_fields_savedsearches0* SKIPPED*",
     "*test_splunk_fiction_indextime_broken.py::Test_App::test_requirements_fields[splunk_searchtime_fields_requirements0* SKIPPED*",
-    "*test_splunk_app_cim_fiction.py::Test_App::test_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*",
+    "*test_splunk_fiction_indextime_broken.py::Test_App::test_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*",
 ]
 """
 Define TA_requirement_tests passed test

--- a/tests/e2e/constants.py
+++ b/tests/e2e/constants.py
@@ -479,10 +479,6 @@ TA_CIM_BROKEN_FAILED = [
     '*test_splunk_app_cim_broken.py::Test_App::test_cim_required_fields*eventtype="eventtype_splunkd_broken_with_eval"::Broken_Eval::fail_multi_value_field* FAILED*',
 ]
 
-TA_CIM_BROKEN_SKIPPED = [
-    "*test_splunk_app_cim_broken.py::Test_App::test_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*"
-]
-
 """
 Define the TA_fiction_indextime add-on passed test case list.
 """

--- a/tests/e2e/constants.py
+++ b/tests/e2e/constants.py
@@ -392,7 +392,6 @@ TA_BROKEN_FAILED = [
 
 TA_BROKEN_SKIPPED = [
     "*test_splunk_app_broken.py::Test_App::test_requirements_fields[splunk_searchtime_fields_requirements0* SKIPPED*",
-    "*test_splunk_app_broken.py::Test_App::test_cim_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*",
 ]
 
 """
@@ -477,6 +476,10 @@ TA_CIM_BROKEN_FAILED = [
     '*test_splunk_app_cim_broken.py::Test_App::test_cim_required_fields*eventtype="eventtype_splunkd_broken_with_eval"::Broken_Eval::invalid_value_null_1* FAILED*',
     '*test_splunk_app_cim_broken.py::Test_App::test_cim_required_fields*eventtype="eventtype_splunkd_broken_with_eval"::Broken_Eval::invalid_value_null_2* FAILED*',
     '*test_splunk_app_cim_broken.py::Test_App::test_cim_required_fields*eventtype="eventtype_splunkd_broken_with_eval"::Broken_Eval::fail_multi_value_field* FAILED*',
+]
+
+TA_CIM_BROKEN_SKIPPED = [
+    "*test_splunk_app_cim_fiction.py::Test_App::test_cim_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*"
 ]
 
 """

--- a/tests/e2e/constants.py
+++ b/tests/e2e/constants.py
@@ -479,7 +479,7 @@ TA_CIM_BROKEN_FAILED = [
 ]
 
 TA_CIM_BROKEN_SKIPPED = [
-    "*test_splunk_app_cim_fiction.py::Test_App::test_cim_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*"
+    "*test_splunk_app_cim_broken.py::Test_App::test_cim_fields_recommended[splunk_searchtime_cim_fields_recommended0* SKIPPED*"
 ]
 
 """

--- a/tests/e2e/test_splunk_addon.py
+++ b/tests/e2e/test_splunk_addon.py
@@ -348,12 +348,10 @@ def test_splunk_app_cim_broken(testdir):
     result.stdout.fnmatch_lines_random(
         constants.TA_CIM_BROKEN_PASSED
         + constants.TA_CIM_BROKEN_FAILED
-        + constants.TA_CIM_BROKEN_SKIPPED
     )
     result.assert_outcomes(
         passed=len(constants.TA_CIM_BROKEN_PASSED),
-        failed=len(constants.TA_CIM_BROKEN_FAILED),
-        skipped=len(constants.TA_CIM_BROKEN_SKIPPED),
+        failed=len(constants.TA_CIM_BROKEN_FAILED)
     )
 
     # The test suite should fail as this is a negative test
@@ -765,7 +763,7 @@ def test_splunk_app_req(testdir):
         "--search-interval=2",
         "--search-retry=4",
         "--search-index=*",
-        "--splunk-data-generator=tests/addons/TA_transition_from_req/default",
+        "--splunk-data-generator=tests/addons/TA_transition_from_req/default"
     )
     logger.info(result.outlines)
 

--- a/tests/e2e/test_splunk_addon.py
+++ b/tests/e2e/test_splunk_addon.py
@@ -346,12 +346,14 @@ def test_splunk_app_cim_broken(testdir):
 
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines_random(
-        constants.TA_CIM_BROKEN_PASSED + constants.TA_CIM_BROKEN_FAILED + constants.TA_CIM_BROKEN_SKIPPED
+        constants.TA_CIM_BROKEN_PASSED
+        + constants.TA_CIM_BROKEN_FAILED
+        + constants.TA_CIM_BROKEN_SKIPPED
     )
     result.assert_outcomes(
         passed=len(constants.TA_CIM_BROKEN_PASSED),
         failed=len(constants.TA_CIM_BROKEN_FAILED),
-        skipped=len(constants.TA_CIM_BROKEN_SKIPPED)
+        skipped=len(constants.TA_CIM_BROKEN_SKIPPED),
     )
 
     # The test suite should fail as this is a negative test

--- a/tests/e2e/test_splunk_addon.py
+++ b/tests/e2e/test_splunk_addon.py
@@ -291,8 +291,14 @@ def test_splunk_app_cim_fiction(testdir):
         "--search-index=*,_internal",
     )
 
-    result.stdout.fnmatch_lines_random(constants.TA_CIM_FICTION_PASSED)
-    result.assert_outcomes(passed=len(constants.TA_CIM_FICTION_PASSED), failed=0)
+    result.stdout.fnmatch_lines_random(
+        constants.TA_CIM_FICTION_PASSED + constants.TA_CIM_FICTION_SKIPPED
+    )
+    result.assert_outcomes(
+        passed=len(constants.TA_CIM_FICTION_PASSED),
+        failed=0,
+        skipped=len(constants.TA_CIM_FICTION_SKIPPED),
+    )
 
     # make sure that that we get a '0' exit code for the testsuite
     assert result.ret == 0
@@ -340,11 +346,14 @@ def test_splunk_app_cim_broken(testdir):
 
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines_random(
-        constants.TA_CIM_BROKEN_PASSED + constants.TA_CIM_BROKEN_FAILED
+        constants.TA_CIM_BROKEN_PASSED
+        + constants.TA_CIM_BROKEN_FAILED
+        + constants.TA_CIM_BROKEN_SKIPPED
     )
     result.assert_outcomes(
         passed=len(constants.TA_CIM_BROKEN_PASSED),
         failed=len(constants.TA_CIM_BROKEN_FAILED),
+        skipped=len(constants.TA_CIM_BROKEN_SKIPPED),
     )
 
     # The test suite should fail as this is a negative test
@@ -757,7 +766,6 @@ def test_splunk_app_req(testdir):
         "--search-retry=4",
         "--search-index=*",
         "--splunk-data-generator=tests/addons/TA_transition_from_req/default",
-        # "--requirement-test=package/samples",
     )
     logger.info(result.outlines)
 

--- a/tests/e2e/test_splunk_addon.py
+++ b/tests/e2e/test_splunk_addon.py
@@ -346,11 +346,12 @@ def test_splunk_app_cim_broken(testdir):
 
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines_random(
-        constants.TA_CIM_BROKEN_PASSED + constants.TA_CIM_BROKEN_FAILED
+        constants.TA_CIM_BROKEN_PASSED + constants.TA_CIM_BROKEN_FAILED + constants.TA_CIM_BROKEN_SKIPPED
     )
     result.assert_outcomes(
         passed=len(constants.TA_CIM_BROKEN_PASSED),
         failed=len(constants.TA_CIM_BROKEN_FAILED),
+        skipped=len(constants.TA_CIM_BROKEN_SKIPPED)
     )
 
     # The test suite should fail as this is a negative test

--- a/tests/e2e/test_splunk_addon.py
+++ b/tests/e2e/test_splunk_addon.py
@@ -346,12 +346,11 @@ def test_splunk_app_cim_broken(testdir):
 
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines_random(
-        constants.TA_CIM_BROKEN_PASSED
-        + constants.TA_CIM_BROKEN_FAILED
+        constants.TA_CIM_BROKEN_PASSED + constants.TA_CIM_BROKEN_FAILED
     )
     result.assert_outcomes(
         passed=len(constants.TA_CIM_BROKEN_PASSED),
-        failed=len(constants.TA_CIM_BROKEN_FAILED)
+        failed=len(constants.TA_CIM_BROKEN_FAILED),
     )
 
     # The test suite should fail as this is a negative test
@@ -763,7 +762,7 @@ def test_splunk_app_req(testdir):
         "--search-interval=2",
         "--search-retry=4",
         "--search-index=*",
-        "--splunk-data-generator=tests/addons/TA_transition_from_req/default"
+        "--splunk-data-generator=tests/addons/TA_transition_from_req/default",
     )
     logger.info(result.outlines)
 


### PR DESCRIPTION
PR created to include requirement unit test into PSA (for now stored in [splunk/addonfactory-workflow-requirement-files-unit-test](https://github.com/splunk/addonfactory-workflow-requirement-files-unit-tests) In general, There are two checks added:

- one of the recommended fields implemented previously [here](https://github.com/splunk/addonfactory-workflow-requirement-files-unit-tests/blob/main/test_lib/test_cim.py) - now it is a new cim test. New fixture was added - `splunk_dm_recommended_fields` to get datamodel definition. The new approach was used here instead of a static definition API call to Splunk instance is performed. It requires CIM Add-on to be installed in the Splunk test environment, but it was already added previously.

- schema validation from [here](https://github.com/splunk/addonfactory-workflow-requirement-files-unit-tests/blob/main/test_lib/validate_xml.py) in PSA is done during samples generations, so if the schema is not valid it would raise an error right away. It is not a test just check in the code

The rest of the checks from `addonfactory-workflow-requirement-files-unit-test` should be covered by schema validation

PR created as a part of [sample/tests unification](https://splunk.atlassian.net/browse/AQA-264) epic. Task [JIRA](https://splunk.atlassian.net/browse/AQA-453)