### PR TITLE
chore: sample splitter script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ pytest11 = { plugin = "pytest_splunk_addon.plugin", "splunk" = "pytest_splunk_ad
 [tool.poetry.scripts]
 cim-report = 'pytest_splunk_addon.standard_lib.utilities.junit_parser:main'
 cim-field-report = 'pytest_splunk_addon.tools.cim_field_report:main'
+sample_splitter = 'pytest_splunk_addon.standard_lib.utilities.sample_splitter:main'
 
 [build-system]
 requires = ["poetry>=1.0.2"]

--- a/pytest_splunk_addon/standard_lib/utilities/sample_splitter.py
+++ b/pytest_splunk_addon/standard_lib/utilities/sample_splitter.py
@@ -47,7 +47,8 @@ def split_samples(sample_path, output_dir=None, splitter="sourcetype"):
     for splitter_name, events in separate_events.items():
         samples["device"].update(event=events)
         output_file = sample_file_name.split(".")
-        output_file.insert(-2, splitter_name)
+        parsed_splitter_name = splitter_name.replace("/", "").replace("\\", "")
+        output_file.insert(-2, parsed_splitter_name)
         output_file_name = ".".join(output_file)
         with open(
             os.path.join(output_dir, output_file_name), "w", encoding="utf-8"


### PR DESCRIPTION
install script
fix for spitters contain '/'