### PR TITLE
fix: handling of static source

### DIFF
--- a/pytest_splunk_addon/standard_lib/sample_generation/sample_stanza.py
+++ b/pytest_splunk_addon/standard_lib/sample_generation/sample_stanza.py
@@ -306,6 +306,9 @@ class SampleStanza(object):
                     static_host = each_event["transport"].get("@host")
                     if static_host:
                         event_metadata.update(host=static_host)
+                    static_source = each_event["transport"].get("@source")
+                    if static_source:
+                        event_metadata.update(source=static_source)
                 yield SampleEvent(
                     event, event_metadata, self.sample_name, requirement_test_data
                 )


### PR DESCRIPTION
Handling of static defined value of source in transport tag. This allows to define different sources per event in single samples file.