### PR TITLE
Remove lock on unconfigure

### DIFF
--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -954,3 +954,4 @@ def pytest_unconfigure(config):
             os.remove(PYTEST_XDIST_TESTRUNUID + "_events")
         if os.path.exists(PYTEST_XDIST_TESTRUNUID + "_events.lock"):
             os.remove(PYTEST_XDIST_TESTRUNUID + "_events.lock")
+

--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -952,3 +952,5 @@ def pytest_unconfigure(config):
             os.remove(PYTEST_XDIST_TESTRUNUID + "_wait")
         if os.path.exists(PYTEST_XDIST_TESTRUNUID + "_events"):
             os.remove(PYTEST_XDIST_TESTRUNUID + "_events")
+        if os.path.exists(PYTEST_XDIST_TESTRUNUID + "_events.lock"):
+            os.remove(PYTEST_XDIST_TESTRUNUID + "_events.lock")


### PR DESCRIPTION
At the end of the test suite file <ID>_event is deleted, but <ID>_even.lock is not. This PR fixes it