### PR TITLE
fix: Updated search query for untokenized events test case

### DIFF
--- a/pytest_splunk_addon/standard_lib/addon_basic.py
+++ b/pytest_splunk_addon/standard_lib/addon_basic.py
@@ -50,7 +50,7 @@ class Basic(FieldTestTemplates, CIMTestTemplates, IndexTimeTestTemplate):
             record_property (fixture): Document facts of test cases.
 
         """
-        query = f"search index=* ##*## | stats count by source, sourcetype"
+        query = f"""search index=* | regex "##[a-zA-Z0-9_-]+##" | stats count by source, sourcetype"""
         record_property("Query", query)
         results = list(
             splunk_search_util.getFieldValuesList(


### PR DESCRIPTION
A search query for test_events_with_untokenised_values is updated so token name could have only alphanumerical characters with 2 special characters hyphen and an underscore. 
Ref: https://splunk.atlassian.net/browse/AQA-76