### PR TITLE
fix: escape double quote

### DIFF
--- a/pytest_splunk_addon/standard_lib/utilities/xml_event_parser.py
+++ b/pytest_splunk_addon/standard_lib/utilities/xml_event_parser.py
@@ -100,6 +100,7 @@ def escape_char_event(event):
         "WHERE",
         "LIKE",
         "NOT",
+        '"',
     ]
     event = event.replace("\\", "\\\\")
     bounded_asterisk = re.search(r"\".*?\*+.*?\"", event)


### PR DESCRIPTION
we're missing escaping double quote sign when we're searching for a row event in test_requirements_fields
this is fix for https://splunk.atlassian.net/browse/AQA-950