### PR TITLE
fix: update splunksplwrapper dep where it retries service init

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1174,4 +1174,4 @@ docker = ["lovely-pytest-docker"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "fee729318428c0fbdd30094888d93ad666bc2a0f623f5cadd13546490851ab96"
+content-hash = "311179a67f96d04babb629af5b668c205ad0f3a633b0d9d067ccda4e23331e2f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ defusedxml = "^0.7.1"
 Faker = ">=13.12,<19.0.0"
 xmltodict = "^0.13.0"
 xmlschema = "^1.11.3"
-splunksplwrapper = "^1.0.1"
+splunksplwrapper = "^1.0.2"
 urllib3 = "<2"
 
 [tool.poetry.extras]


### PR DESCRIPTION
PSA sometimes throws an error "Temporary failure in name resolution" which makes some tests to fail which results in a retry which takes time and is not reliable.

The specific log can be found here: https://github.com/splunk/splunk-add-on-for-cisco-asa/actions/runs/4627279372/job/12563451275

PSA uses splunksplwrapper (helmut) to make requests to Splunk itself, so the fix for this problem is to improve that library. The merged fix can be found [here](https://github.com/splunk/splunksplwrapper/pull/55). It makes splunksplwrapper to retry failed requests up to 3 times with 5 seconds delay. This should increase the reliability of the tests.