### PR TITLE
feat: splunk hec token handling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ version: "3.7"
 services:
 
   sc4s:
+    platform: linux/amd64
     image: ghcr.io/splunk/splunk-connect-for-syslog/container2:latest
     hostname: sc4s
     #When this is enabled test_common will fail
@@ -38,8 +39,6 @@ services:
       - "6514"
     stdin_open: true
     tty: true
-    links:
-      - splunk
     environment:
       - SPLUNK_HEC_URL=https://splunk:8088
       - SPLUNK_HEC_TOKEN=${SPLUNK_HEC_TOKEN}
@@ -62,6 +61,7 @@ services:
       - SC4S_LISTEN_CHECKPOINT_SPLUNK_NOISE_CONTROL=yes
 
   splunk:
+    platform: linux/amd64
     build:
       context: .
       dockerfile: Dockerfile.splunk
@@ -81,6 +81,7 @@ services:
       - TEST_SC4S_ACTIVATE_EXAMPLES=yes
 
   uf:
+    platform: linux/amd64
     build:
       context: .
       dockerfile: Dockerfile.uf
@@ -92,8 +93,6 @@ services:
     ports:
       - "9997"
       - "8089"
-    links:
-      - splunk
     environment:
       - SPLUNK_PASSWORD=Chang3d!
       - SPLUNK_START_ARGS=--accept-license

--- a/pytest_splunk_addon/plugin.py
+++ b/pytest_splunk_addon/plugin.py
@@ -25,9 +25,8 @@ LOG_FILE = "pytest_splunk_addon.log"
 
 test_generator = None
 
-EXC_MAP = {
-        Exception: 1
-    }
+EXC_MAP = {Exception: 1}
+
 
 def pytest_configure(config):
     """
@@ -211,6 +210,7 @@ def pytest_exception_interact(node, call, report):
             pytest.exit(f"Reached max exception for type: {type_}")
         else:
             session.__exc_limits[type_] -= 1
-            
+
+
 init_pytest_splunk_addon_logger()
 LOGGER = logging.getLogger("pytest-splunk-addon")

--- a/pytest_splunk_addon/plugin.py
+++ b/pytest_splunk_addon/plugin.py
@@ -202,6 +202,11 @@ def init_pytest_splunk_addon_logger():
 
 
 def pytest_exception_interact(node, call, report):
+    """
+    Hook called when an exception is raised during a test.
+    If the number of occurrences for a specific exception exceeds the limit in session.__exc_limits, pytest exits
+    https://docs.pytest.org/en/stable/reference/reference.html#pytest.hookspec.pytest_exception_interact
+    """
     session = node.session
     type_ = call.excinfo.type
 

--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -721,7 +721,7 @@ def create_hec_token(request, splunk_inputs_uri):
 
 def _create_new_token(request, splunk_inputs_uri, splunk_token_name):
     try:
-        response = requests.post(  # nosemgrep: splunk.disabled-cert-validation
+        response = requests.post(
             splunk_inputs_uri,
             verify=False,
             auth=(
@@ -747,7 +747,7 @@ def _create_new_token(request, splunk_inputs_uri, splunk_token_name):
 
 def _get_existing_token(request, splunk_inputs_uri, splunk_token_name):
     try:
-        response = requests.get(  # nosemgrep: splunk.disabled-cert-validation
+        response = requests.get(
             f"{splunk_inputs_uri}/{splunk_token_name}",
             verify=False,
             auth=(
@@ -967,7 +967,6 @@ def is_responsive_splunk(splunk):
         )
 
         LOGGER.info("Connected to Splunk instance.")
-        # sleep(30)
         return True
     except Exception as e:
         LOGGER.warning(
@@ -998,12 +997,37 @@ def is_responsive_hec(request, splunk):
         LOGGER.debug("Status code: {}".format(response.status_code))
         if response.status_code in (200, 201):
             LOGGER.info("Splunk HEC is responsive.")
-            sleep(10)
+            sleep(20)
             return True
         return False
     except Exception as e:
         LOGGER.warning(
             "Could not connect to Splunk HEC. Will try again. exception=%s",
+            str(e),
+        )
+        return False
+
+
+def is_responsive(url):
+    """
+    This function is called to verify the connection is accepted
+    used to prevent tests from running before Splunk is ready
+
+    Args:
+        url (str): url to check if it's responsive or not
+
+    Returns:
+        bool: True if Splunk is responsive. False otherwise
+    """
+    try:
+        LOGGER.info("Trying to connect with url=%s", url)
+        response = requests.get(url)
+        if response.status_code != 500:
+            LOGGER.info("Connected to the url")
+            return True
+    except ConnectionError as e:
+        LOGGER.warning(
+            "Could not connect to url yet. Will try again. exception=%s",
             str(e),
         )
         return False

--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -721,7 +721,7 @@ def create_hec_token(request, splunk_inputs_uri):
 
 def _create_new_token(request, splunk_inputs_uri, splunk_token_name):
     try:
-        response = requests.post(
+        response = requests.post(  # nosemgrep: splunk.disabled-cert-validation
             splunk_inputs_uri,
             verify=False,
             auth=(
@@ -747,7 +747,7 @@ def _create_new_token(request, splunk_inputs_uri, splunk_token_name):
 
 def _get_existing_token(request, splunk_inputs_uri, splunk_token_name):
     try:
-        response = requests.get(
+        response = requests.get(  # nosemgrep: splunk.disabled-cert-validation
             f"{splunk_inputs_uri}/{splunk_token_name}",
             verify=False,
             auth=(

--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -44,6 +44,7 @@ class HecTokenNotExistingError(Exception):
         self.message = message
         super().__init__(self.message)
 
+
 def pytest_addoption(parser):
     """Add options for interaction with Splunk this allows the tool to work in two modes
     1) docker mode which is typically used by developers on their workstation
@@ -708,12 +709,16 @@ def get_hec_token(request, splunk_inputs_uri):
     """
     LOGGER.info(f"Attempting to create HEC token")
     try:
-        response = _get_existing_token(request, splunk_inputs_uri, SPLUNK_HEC_TOKEN_NAME)
+        response = _get_existing_token(
+            request, splunk_inputs_uri, SPLUNK_HEC_TOKEN_NAME
+        )
         token_value = _extract_token_from_xml(response.text)
         LOGGER.info(f"Retrieved HEC token: {token_value}")
     except HecTokenNotExistingError:
         _create_new_token(request, splunk_inputs_uri, SPLUNK_HEC_TOKEN_NAME)
-        response = _get_existing_token(request, splunk_inputs_uri, SPLUNK_HEC_TOKEN_NAME)
+        response = _get_existing_token(
+            request, splunk_inputs_uri, SPLUNK_HEC_TOKEN_NAME
+        )
         token_value = _extract_token_from_xml(response.text)
         LOGGER.info(f"Created HEC token: {token_value}")
     except Exception as e:
@@ -771,7 +776,9 @@ def _get_existing_token(request, splunk_inputs_uri, splunk_token_name):
 
     except Exception as e:
         LOGGER.error(f"Failed to retrieve existing HEC token: {e}")
-        raise HecTokenNotExistingError(f"Failed to retrieve existing HEC token: {e}") from e
+        raise HecTokenNotExistingError(
+            f"Failed to retrieve existing HEC token: {e}"
+        ) from e
 
 
 def _extract_token_from_xml(xml_content):


### PR DESCRIPTION
- add self handling for HEC token - PSA now discovers or creates HEC token if it is missing and passes to other deployments. For backward compatibility, if splunk-hec-token is provided via CL argument, this approach is not being used
- splunk-hec-token CLI argument no longer has default value
- add `pytest_exception_interact` in plugin.py to exit entire test suite in case of `Exception` occurence
