### PR TITLE
fix: ADDON-66599 deprecate splunk-hec-token default value and break test execution on exception

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -186,6 +186,7 @@ jobs:
           "splunk_app_cim_broken",
           "splunk_fiction_indextime",
           "splunk_fiction_indextime_broken",
+          "splunk_fiction_indextime_wrong_hec_token",
           "splunk_setup_fixture",
           "splunk_app_req",
           "splunk_app_req_broken",

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ test_report.md
 *.pickle
 *_events.lock
 *_events
+.venv

--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -110,7 +110,7 @@ def pytest_addoption(parser):
         action="store",
         dest="splunk_hec_token",
         default="9b741d03-43e9-4164-908b-e09102327d22",
-        help='Splunk HTTP event collector token. default is "9b741d03-43e9-4164-908b-e09102327d22" If an external forwarder is used provide HEC token of forwarder.',
+        help="Splunk HTTP event collector token. If an external forwarder is used provide HEC token of forwarder. Please specify it as default value is going to be deprecated.",
     )
     group.addoption(
         "--splunk-port",
@@ -552,6 +552,7 @@ def splunk_docker(
         # get the temp directory shared by all workers
         root_tmp_dir = tmp_path_factory.getbasetemp().parent
         fn = root_tmp_dir / "pytest_docker"
+        # if you encounter docker-compose not found modify shell path in your IDE to use /bin/bash
         with FileLock(str(fn) + ".lock"):
             docker_services.start("splunk")
 
@@ -576,11 +577,12 @@ def splunk_docker(
         docker_services.port_for("splunk", 9997),
     )
 
-    docker_services.wait_until_responsive(
-        timeout=180.0,
-        pause=0.5,
-        check=lambda: is_responsive_splunk(splunk_info),
-    )
+    for _ in range(RESPONSIVE_SPLUNK_TIMEOUT):
+        if is_responsive_splunk(splunk_info) and is_responsive_hec(
+            request, splunk_info
+        ):
+            break
+        sleep(1)
 
     return splunk_info
 
@@ -610,9 +612,9 @@ def splunk_external(request):
         )
 
     for _ in range(RESPONSIVE_SPLUNK_TIMEOUT):
-        if is_responsive_splunk(splunk_info):
-            break
-        if is_responsive_hec(request, splunk_info):
+        if is_responsive_splunk(splunk_info) and is_responsive_hec(
+            request, splunk_info
+        ):
             break
         sleep(1)
 

--- a/tests/e2e/incorrect_hec_token_conftest.py
+++ b/tests/e2e/incorrect_hec_token_conftest.py
@@ -1,0 +1,44 @@
+import os
+import pytest
+import requests
+
+pytest_plugins = "pytester"
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "external: Test search time only")
+    config.addinivalue_line("markers", "docker: Test search time only")
+    config.addinivalue_line("markers", "doc: Test Sphinx docs")
+
+
+@pytest.fixture(scope="session")
+def docker_compose_files(request):
+    """
+    Get an absolute path to the  `docker-compose.yml` file. Override this
+    fixture in your tests if you need a custom location.
+
+    Returns:
+        string: the path of the `docker-compose.yml` file
+
+    """
+    docker_compose_path = os.path.join(
+        str(request.config.invocation_dir), "docker-compose.yml"
+    )
+    # LOGGER.info("docker-compose path: %s", docker_compose_path)
+
+    return [docker_compose_path]
+
+
+@pytest.fixture(scope="session")
+def docker_services_project_name(pytestconfig):
+    rootdir = str(pytestconfig.rootdir)
+    docker_compose_v2_rootdir = rootdir.lower().replace("/", "")
+    return f"pytest{docker_compose_v2_rootdir}"
+
+
+@pytest.fixture(scope="session")
+def splunk_hec_uri(splunk, request):
+    splunk_session = requests.Session()
+    splunk_session.headers = {"Authorization": f"Splunk test-token"}
+    uri = f'{request.config.getoption("splunk_hec_scheme")}://{splunk["forwarder_host"]}:{splunk["port_hec"]}/services/collector'
+    return splunk_session, uri


### PR DESCRIPTION
Changes:

- deprecate default value of splunk-hec-token - give a warning when it's used
- add console handler to logger - warnings and errors beside being logged to pytest_splunk_addon.log are also logged to console
- other minor refactors from PR-803

Already released on develop and tested on couple of repos.

https://github.com/splunk/splunk-add-on-for-google-workspace/pull/515

References:
https://splunk.atlassian.net/browse/ADDON-66599
https://github.com/splunk/pytest-splunk-addon/pull/803/files

---------