### PR TITLE
fix: accept any version of addonfactory-splunk-conf-parser-lib

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1123,4 +1123,4 @@ docker = ["lovely-pytest-docker"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "3991846ee08d8361150ea70124cda97fdb6ceb243f8fa2e3865b89e6ace8056a"
+content-hash = "6056c13e8dac09f82ef6f6a7f2b0f1b86ebe4cf113df71fe5d81574abee94daf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ filelock = "^3.0"
 pytest-ordering = "~0.6"
 lovely-pytest-docker = { version="^0", optional = true }
 junitparser = "^2.2.0"
-addonfactory-splunk-conf-parser-lib = "^0.3.3"
+addonfactory-splunk-conf-parser-lib = "*"
 defusedxml = "^0.7.1"
 Faker = ">=13.12,<19.0.0"
 xmltodict = "^0.13.0"


### PR DESCRIPTION
This PR makes it so PSA accepts any version of `addonfactory-splunk-conf-parser-lib` (Splunk-owned library).