### PR TITLE
fix: update of pytest-xdist version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -443,13 +443,13 @@ files = [
 
 [[package]]
 name = "jinja2"
-version = "3.0.3"
+version = "3.1.3"
 description = "A very fast and expressive template engine."
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "Jinja2-3.0.3-py3-none-any.whl", hash = "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8"},
-    {file = "Jinja2-3.0.3.tar.gz", hash = "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"},
+    {file = "Jinja2-3.1.3-py3-none-any.whl", hash = "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa"},
+    {file = "Jinja2-3.1.3.tar.gz", hash = "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90"},
 ]
 
 [package.dependencies]
@@ -1150,4 +1150,4 @@ docker = ["lovely-pytest-docker"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "6056c13e8dac09f82ef6f6a7f2b0f1b86ebe4cf113df71fe5d81574abee94daf"
+content-hash = "384db44b6bda065e8afbb4574d233e623f54d86f7a12adba698830a655d6adf3"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1150,4 +1150,4 @@ docker = ["lovely-pytest-docker"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "a82aab88272cfc01da1f856591b25876d72f957c1b736901120e916a6e56fdc9"
+content-hash = "6056c13e8dac09f82ef6f6a7f2b0f1b86ebe4cf113df71fe5d81574abee94daf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ pytest = ">5.4.0,<8"
 splunk-sdk = ">=1.6"
 requests = "^2.31.0"
 jsonschema = ">=4,<5"
-pytest-xdist = "^2.3.0"
+pytest-xdist = ">=2.3.0"
 filelock = "^3.0"
 pytest-ordering = "~0.6"
 lovely-pytest-docker = { version="^0", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ pytz = "^2022.1"
 optional = true
 
 [tool.poetry.group.docs.dependencies]
-jinja2 = "3.0.3"
+jinja2 = "3.1.3"
 sphinx-rtd-theme = "1.1.1"
 sphinx-panels = "0.6.0"
 


### PR DESCRIPTION
PR takes back the limitation imposed on pytest-xdist version. There are no false positive tests results. The behaviour is expected. 
[ADDON-67668](https://splunk.atlassian.net/browse/ADDON-67668)
