### PR TITLE
fix: handling infinite loop

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -136,19 +136,16 @@ jobs:
         run: |
           pip install git+https://github.com/pixelb/crudini
           mkdir test-results-${{ matrix.splunk.version }}
-      - name: Splunk Up
-        run: |
-          export SPLUNK_APP_PACKAGE=./tests/e2e/addons/TA_fiction
-          export SPLUNK_ADDON=TA_fiction
-          export SPLUNK_APP_ID=TA_fiction
-          export SPLUNK_VERSION=${{ matrix.splunk.version }}
-          echo $SPLUNK_VERSION
-          docker-compose -f "docker-compose-ci.yml" build
-          SPLUNK_PASSWORD=Chang3d! docker-compose -f docker-compose-ci.yml up -d splunk
-          sleep 90
       - name: Test
         run: |
-          SPLUNK_PASSWORD=Chang3d! docker-compose -f docker-compose-ci.yml up --abort-on-container-exit
+          export SPLUNK_APP_PACKAGE=./tests/e2e/addons/TA_fiction_indextime
+          export SPLUNK_ADDON=TA_fiction_indextime
+          export SPLUNK_APP_ID=TA_fiction_indextime
+          export SPLUNK_VERSION=${{ matrix.splunk.version }}
+          export SPLUNK_HEC_TOKEN="9b741d03-43e9-4164-908b-e09102327d22"
+          echo $SPLUNK_VERSION
+          docker compose -f "docker-compose-ci.yml" build
+          SPLUNK_PASSWORD=Chang3d! docker compose -f docker-compose-ci.yml up --abort-on-container-exit
           docker volume ls
       - name: Collect Results
         run: |

--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -741,18 +741,21 @@ def splunk_ingest_data(request, splunk_hec_uri, sc4s, uf, splunk_events_cleanup)
         }
         thread_count = int(request.config.getoption("thread_count"))
         store_events = request.config.getoption("store_events")
-        IngestorHelper.ingest_events(
-            ingest_meta_data,
-            addon_path,
-            config_path,
-            thread_count,
-            store_events,
-        )
-        sleep(50)
-        if "PYTEST_XDIST_WORKER" in os.environ:
-            with open(os.environ.get("PYTEST_XDIST_TESTRUNUID") + "_wait", "w+"):
-                PYTEST_XDIST_TESTRUNUID = os.environ.get("PYTEST_XDIST_TESTRUNUID")
-
+        try:
+            IngestorHelper.ingest_events(
+                ingest_meta_data,
+                addon_path,
+                config_path,
+                thread_count,
+                store_events,
+            )
+            sleep(50)
+        except Exception as e:
+            raise e
+        finally:
+            if "PYTEST_XDIST_WORKER" in os.environ:
+                with open(os.environ.get("PYTEST_XDIST_TESTRUNUID") + "_wait", "w+"):
+                    PYTEST_XDIST_TESTRUNUID = os.environ.get("PYTEST_XDIST_TESTRUNUID")
     else:
         while not os.path.exists(os.environ.get("PYTEST_XDIST_TESTRUNUID") + "_wait"):
             sleep(1)

--- a/tests/e2e/test_splunk_addon.py
+++ b/tests/e2e/test_splunk_addon.py
@@ -740,6 +740,7 @@ def test_splunk_app_req(testdir, request):
     # make sure that we get a non '0' exit code for the testsuite as it contains failure
     assert result.ret == 0, "result not equal to 0"
 
+
 @pytest.mark.test_infinite_loop_fixture
 @pytest.mark.docker
 @pytest.mark.external

--- a/tests/e2e/test_splunk_addon.py
+++ b/tests/e2e/test_splunk_addon.py
@@ -770,7 +770,7 @@ def test_infinite_loop_in_ingest_data_fixture(testdir, request):
     Rule.clean_rules()
 
     # run pytest with the following cmd args
-    # we are providing wrong sc4s service details here so that we can recreate scenario where first worked raises execption and other workers get stuck
+    # we are providing wrong sc4s service details here so that we can recreate scenario where first worked raises exception and other workers get stuck
     result = testdir.runpytest(
         "--splunk-app=addons/TA_fiction_indextime",
         "--splunk-type=external",

--- a/tests/e2e/test_splunk_addon.py
+++ b/tests/e2e/test_splunk_addon.py
@@ -742,7 +742,6 @@ def test_splunk_app_req(testdir, request):
 
 
 @pytest.mark.test_infinite_loop_fixture
-@pytest.mark.docker
 @pytest.mark.external
 def test_infinite_loop_in_ingest_data_fixture(testdir, request):
     """Make sure that pytest accepts our fixture."""
@@ -771,6 +770,7 @@ def test_infinite_loop_in_ingest_data_fixture(testdir, request):
     Rule.clean_rules()
 
     # run pytest with the following cmd args
+    # we are providing wrong sc4s service details here so that we can recreate scenario where first worked raises execption and other workers get stuck
     result = testdir.runpytest(
         "--splunk-app=addons/TA_fiction_indextime",
         "--splunk-type=external",
@@ -781,6 +781,6 @@ def test_infinite_loop_in_ingest_data_fixture(testdir, request):
         "-n 2",
     )
 
-    # fnmatch_lines does an assertion internally Here we are not interested in the failures or errors,
+    # Here we are not interested in the failures or errors,
     # we are basically checking that we get results and test execution does not get stuck
     assert result.parseoutcomes().get("passed") > 0


### PR DESCRIPTION
There was a bug in PSA where if in splunk_ingest_data first worker errors out or throws exception then it does not write to a file, now other workers would be waiting indefinitely for the file to be present, So the execution would continue in infinitly.

To handle this scenario, we can handle the exception thrown by the first worker and make sure that in any case it writes to a file, so that other workers don't wait indefinitly