### PR TITLE
Ci/fixing e2e tests

### DIFF
--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -27,7 +27,7 @@ RUN export DEBIAN_FRONTEND=noninteractive ;\
     apt-get install -y --no-install-recommends apt-utils ;\
     apt-get install -y locales ;\
     localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8;\
-    apt-get install -y curl git python-is-python3 python3-distutils python3-pip
+    apt-get install -y curl git python-is-python3 python3-pip
 
 ENV LANG en_US.utf8
 

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -27,7 +27,7 @@ RUN export DEBIAN_FRONTEND=noninteractive ;\
     apt-get install -y --no-install-recommends apt-utils ;\
     apt-get install -y locales ;\
     localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8;\
-    apt-get install -y curl git python-is-python3 python3-pip
+    apt-get install -y curl git python-is-python3 python3-pip python3-venv
 
 ENV LANG en_US.utf8
 


### PR DESCRIPTION
- Latest ubuntu [image](https://hub.docker.com/layers/library/ubuntu/latest/images/sha256-31e02f893eaf7729befc0e21920e63b968bffe76760943a6f56fa1c7f3abb055?context=explore) was released sometime back and its packages install latest python which is python3.12
- And in latest python distutils is deprecated hence removing it.
