### PR TITLE
ci(release): allow beta versions for pyproject.toml file

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -43,7 +43,7 @@
             },
             {
               "files": ["pyproject.toml"],
-              "from": "version = \"[0-9]+.[0-9]+.[0-9]+\"",
+              "from": "version = \".*\"",
               "to": "version = \"${nextRelease.version}\"",
               "results": [
                 {


### PR DESCRIPTION
Similar as in https://github.com/splunk/addonfactory-solutions-library-python/blob/c14f9909ce1228a2896a81689dc58989eb9d341c/.releaserc#L31C1-L32C60.