### PR TITLE
fix: do not log .conf parser warnings from all workers

### DIFF
--- a/pytest_splunk_addon/standard_lib/addon_parser/props_parser.py
+++ b/pytest_splunk_addon/standard_lib/addon_parser/props_parser.py
@@ -110,10 +110,9 @@ class PropsParser(object):
                 LOGGER.info(f"Matched method of type={each_type}")
                 return method_mapping[each_type]
         else:
-            if (
-                not os.environ.get("PYTEST_XDIST_WORKER")
-                or os.environ.get("PYTEST_XDIST_WORKER") == "gw0"
-            ):
+            from ...splunk import check_first_worker  # avoiding circular import
+
+            if check_first_worker():
                 LOGGER.warning(f"No parser available for {class_name}. Skipping...")
 
     def _get_props_stanzas(self) -> Optional[Generator]:

--- a/pytest_splunk_addon/standard_lib/addon_parser/props_parser.py
+++ b/pytest_splunk_addon/standard_lib/addon_parser/props_parser.py
@@ -110,7 +110,10 @@ class PropsParser(object):
                 LOGGER.info(f"Matched method of type={each_type}")
                 return method_mapping[each_type]
         else:
-            if not os.environ.get("PYTEST_XDIST_WORKER") or os.environ.get("PYTEST_XDIST_WORKER") == "gw0":
+            if (
+                not os.environ.get("PYTEST_XDIST_WORKER")
+                or os.environ.get("PYTEST_XDIST_WORKER") == "gw0"
+            ):
                 LOGGER.warning(f"No parser available for {class_name}. Skipping...")
 
     def _get_props_stanzas(self) -> Optional[Generator]:
@@ -301,7 +304,7 @@ class PropsParser(object):
         """
         parsed_fields = self._parse_lookup(value)
         lookup_field_list = (
-                parsed_fields["input_fields"] + parsed_fields["output_fields"]
+            parsed_fields["input_fields"] + parsed_fields["output_fields"]
         )
 
         # If the OUTPUT or OUTPUTNEW argument is never used, then get the fields from the csv file

--- a/pytest_splunk_addon/standard_lib/addon_parser/props_parser.py
+++ b/pytest_splunk_addon/standard_lib/addon_parser/props_parser.py
@@ -110,7 +110,8 @@ class PropsParser(object):
                 LOGGER.info(f"Matched method of type={each_type}")
                 return method_mapping[each_type]
         else:
-            LOGGER.warning(f"No parser available for {class_name}. Skipping...")
+            if not os.environ.get("PYTEST_XDIST_WORKER") or os.environ.get("PYTEST_XDIST_WORKER") == "gw0":
+                LOGGER.warning(f"No parser available for {class_name}. Skipping...")
 
     def _get_props_stanzas(self) -> Optional[Generator]:
         """
@@ -300,7 +301,7 @@ class PropsParser(object):
         """
         parsed_fields = self._parse_lookup(value)
         lookup_field_list = (
-            parsed_fields["input_fields"] + parsed_fields["output_fields"]
+                parsed_fields["input_fields"] + parsed_fields["output_fields"]
         )
 
         # If the OUTPUT or OUTPUTNEW argument is never used, then get the fields from the csv file

--- a/pytest_splunk_addon/standard_lib/addon_parser/props_parser.py
+++ b/pytest_splunk_addon/standard_lib/addon_parser/props_parser.py
@@ -28,6 +28,7 @@ import addonfactory_splunk_conf_parser_lib as conf_parser
 
 from .fields import convert_to_fields
 from .transforms_parser import TransformsParser
+from pytest_splunk_addon.standard_lib import utils
 
 LOGGER = logging.getLogger("pytest-splunk-addon")
 
@@ -110,9 +111,7 @@ class PropsParser(object):
                 LOGGER.info(f"Matched method of type={each_type}")
                 return method_mapping[each_type]
         else:
-            from ...splunk import check_first_worker  # avoiding circular import
-
-            if check_first_worker():
+            if utils.check_first_worker():
                 LOGGER.warning(f"No parser available for {class_name}. Skipping...")
 
     def _get_props_stanzas(self) -> Optional[Generator]:

--- a/pytest_splunk_addon/standard_lib/sample_generation/sample_xdist_generator.py
+++ b/pytest_splunk_addon/standard_lib/sample_generation/sample_xdist_generator.py
@@ -28,14 +28,12 @@ class SampleXdistGenerator:
         self.config_path = config_path
 
     def get_samples(self, store_events):
+        from ...splunk import check_first_worker  # avoiding circular import
 
         if self.tokenized_event_source == "pregenerated":
             with open(self.event_path, "rb") as file_obj:
                 store_sample = pickle.load(file_obj)
-                if store_events and (
-                    "PYTEST_XDIST_WORKER" not in os.environ
-                    or os.environ.get("PYTEST_XDIST_WORKER") == "gw0"
-                ):
+                if store_events and check_first_worker():
                     try:
                         tokenized_events = store_sample.get("tokenized_events")
                         self.store_events(tokenized_events)

--- a/pytest_splunk_addon/standard_lib/sample_generation/sample_xdist_generator.py
+++ b/pytest_splunk_addon/standard_lib/sample_generation/sample_xdist_generator.py
@@ -20,6 +20,8 @@ from filelock import FileLock
 import json
 import pytest
 
+from pytest_splunk_addon.standard_lib import utils
+
 
 class SampleXdistGenerator:
     def __init__(self, addon_path, config_path=None, process_count=4):
@@ -28,12 +30,10 @@ class SampleXdistGenerator:
         self.config_path = config_path
 
     def get_samples(self, store_events):
-        from ...splunk import check_first_worker  # avoiding circular import
-
         if self.tokenized_event_source == "pregenerated":
             with open(self.event_path, "rb") as file_obj:
                 store_sample = pickle.load(file_obj)
-                if store_events and check_first_worker():
+                if store_events and utils.check_first_worker():
                     try:
                         tokenized_events = store_sample.get("tokenized_events")
                         self.store_events(tokenized_events)

--- a/pytest_splunk_addon/standard_lib/utils.py
+++ b/pytest_splunk_addon/standard_lib/utils.py
@@ -1,0 +1,11 @@
+import os
+
+
+def check_first_worker() -> bool:
+    """
+    returns True if the current execution is under gw0 (first worker)
+    """
+    return (
+        "PYTEST_XDIST_WORKER" not in os.environ
+        or os.environ.get("PYTEST_XDIST_WORKER") == "gw0"
+    )

--- a/pytest_splunk_addon/standard_lib/utils.py
+++ b/pytest_splunk_addon/standard_lib/utils.py
@@ -1,3 +1,18 @@
+#
+# Copyright 2024 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 import os
 
 


### PR DESCRIPTION
When tests are ran with multiple workers, duplicate logging is observed because every workers logs the warning.
This PR fixes that.