### PR TITLE
fix: splunk hec token exception handling

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/splunk/addonfactory_test_matrix_splunk.git
 [submodule "deps/apps/Splunk_SA_CIM"]
 	path = deps/apps/Splunk_SA_CIM
-	url = git@github.com:splunk/addonfactory-splunk_sa_cim.git
+	url = https://github.com/splunk/addonfactory-splunk_sa_cim.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/splunk/addonfactory_test_matrix_splunk.git
 [submodule "deps/apps/Splunk_SA_CIM"]
 	path = deps/apps/Splunk_SA_CIM
-	url = https://github.com/splunk/addonfactory-splunk_sa_cim.git
+	url = git@github.com:splunk/addonfactory-splunk_sa_cim.git

--- a/pytest_splunk_addon/event_ingestors/hec_event_ingestor.py
+++ b/pytest_splunk_addon/event_ingestors/hec_event_ingestor.py
@@ -25,6 +25,12 @@ requests.urllib3.disable_warnings()
 LOGGER = logging.getLogger("pytest-splunk-addon")
 
 
+class HECEventIngestorException(Exception):
+    def __init__(self, message="An error occurred while data ingestion."):
+        self.message = message
+        super().__init__(self.message)
+
+
 class HECEventIngestor(EventIngestor):
     """
     Class to ingest event via HEC Event
@@ -142,4 +148,6 @@ class HECEventIngestor(EventIngestor):
 
         except Exception as e:
             LOGGER.error("\n\nAn error occurred while data ingestion.{}".format(e))
-            raise type(e)("An error occurred while data ingestion.{}".format(e))
+            raise HECEventIngestorException(
+                "An error occurred while data ingestion. {}".format(e)
+            )

--- a/pytest_splunk_addon/event_ingestors/hec_event_ingestor.py
+++ b/pytest_splunk_addon/event_ingestors/hec_event_ingestor.py
@@ -25,7 +25,7 @@ requests.urllib3.disable_warnings()
 LOGGER = logging.getLogger("pytest-splunk-addon")
 
 
-class HECEventIngestorException(Exception):
+class HECIngestorException(Exception):
     def __init__(self, message="An error occurred while data ingestion."):
         self.message = message
         super().__init__(self.message)
@@ -148,6 +148,6 @@ class HECEventIngestor(EventIngestor):
 
         except Exception as e:
             LOGGER.error("\n\nAn error occurred while data ingestion.{}".format(e))
-            raise HECEventIngestorException(
+            raise HECIngestorException(
                 "An error occurred while data ingestion. {}".format(e)
             )

--- a/pytest_splunk_addon/event_ingestors/hec_raw_ingestor.py
+++ b/pytest_splunk_addon/event_ingestors/hec_raw_ingestor.py
@@ -21,6 +21,8 @@ import logging
 import os
 import time
 
+from .hec_event_ingestor import HECIngestorException
+
 requests.urllib3.disable_warnings()
 
 LOGGER = logging.getLogger("pytest-splunk-addon")
@@ -130,4 +132,6 @@ class HECRawEventIngestor(EventIngestor):
 
         except Exception as e:
             LOGGER.error("\n\nAn error occurred while data ingestion.{}".format(e))
-            raise type(e)("An error occurred while data ingestion.{}".format(e))
+            raise HECIngestorException(
+                "An error occurred while data ingestion.{}".format(e)
+            )

--- a/pytest_splunk_addon/plugin.py
+++ b/pytest_splunk_addon/plugin.py
@@ -17,6 +17,7 @@ import logging
 import pytest
 
 from .app_test_generator import AppTestGenerator
+from .event_ingestors.hec_event_ingestor import HECEventIngestorException
 from .sample_generation.sample_xdist_generator import SampleXdistGenerator
 import traceback
 from .cim_compliance import CIMReportPlugin
@@ -26,7 +27,7 @@ LOG_FILE = "pytest_splunk_addon.log"
 
 test_generator = None
 
-EXC_MAP = [Exception]
+EXC_MAP = [HECEventIngestorException]
 
 
 def pytest_configure(config):

--- a/pytest_splunk_addon/plugin.py
+++ b/pytest_splunk_addon/plugin.py
@@ -226,9 +226,3 @@ def pytest_exception_interact(node, call, report):
     if call.excinfo.type in node.session.__exc_limits:
         # pytest exits only for exceptions defined in EXC_MAP
         pytest.exit(f"Exiting pytest due to: {call.excinfo.type}")
-
-
-def pytest_sessionfinish(session, exitstatus):
-    if os.path.exists("ingestion_error_main_worker.txt"):
-        time.sleep(10)
-        os.remove("ingestion_error_main_worker.txt")

--- a/pytest_splunk_addon/plugin.py
+++ b/pytest_splunk_addon/plugin.py
@@ -14,7 +14,9 @@
 # limitations under the License.
 #
 import logging
+import os
 import pytest
+import time
 
 from .app_test_generator import AppTestGenerator
 from .event_ingestors.hec_event_ingestor import HECEventIngestorException
@@ -224,3 +226,9 @@ def pytest_exception_interact(node, call, report):
     if call.excinfo.type in node.session.__exc_limits:
         # pytest exits only for exceptions defined in EXC_MAP
         pytest.exit(f"Exiting pytest due to: {call.excinfo.type}")
+
+
+def pytest_sessionfinish(session, exitstatus):
+    if os.path.exists("ingestion_error_main_worker.txt"):
+        time.sleep(10)
+        os.remove("ingestion_error_main_worker.txt")

--- a/pytest_splunk_addon/plugin.py
+++ b/pytest_splunk_addon/plugin.py
@@ -19,7 +19,7 @@ import pytest
 import time
 
 from .app_test_generator import AppTestGenerator
-from .event_ingestors.hec_event_ingestor import HECEventIngestorException
+from .event_ingestors.hec_event_ingestor import HECIngestorException
 from .sample_generation.sample_xdist_generator import SampleXdistGenerator
 import traceback
 from .cim_compliance import CIMReportPlugin
@@ -29,7 +29,7 @@ LOG_FILE = "pytest_splunk_addon.log"
 
 test_generator = None
 
-EXC_MAP = [HECEventIngestorException]
+EXC_MAP = {HECIngestorException: 1}
 
 
 def pytest_configure(config):

--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -27,7 +27,7 @@ from splunksplwrapper.manager.jobs import Jobs
 from splunksplwrapper.splunk.cloud import CloudSplunk
 from splunksplwrapper.SearchUtil import SearchUtil
 from .event_ingestors import IngestorHelper
-from .event_ingestors.hec_event_ingestor import HECEventIngestorException
+from .event_ingestors.hec_event_ingestor import HECIngestorException
 from .docker_class import Services
 from .CIM_Models.datamodel_definition import datamodels
 import configparser

--- a/tests/e2e/test_splunk_addon.py
+++ b/tests/e2e/test_splunk_addon.py
@@ -215,7 +215,7 @@ def test_splunk_fiction_indextime_wrong_hec_token(testdir, request):
 
     result.assert_outcomes(errors=1, passed=0, failed=0, xfailed=0)
     result.stdout.fnmatch_lines(
-        "!!!!!! _pytest.outcomes.Exit: Exiting pytest due to: <class 'Exception'> !!!!!!!"
+        "!!!!!! _pytest.outcomes.Exit: Exiting pytest due to: <class 'pytest_splunk_addon.event_ingestors.hec_event_ingestor.HECEventIngestorException'> !!!!!!!"
     )
 
     assert result.ret != 0

--- a/tests/e2e/test_splunk_addon.py
+++ b/tests/e2e/test_splunk_addon.py
@@ -215,7 +215,7 @@ def test_splunk_fiction_indextime_wrong_hec_token(testdir, request):
 
     result.assert_outcomes(errors=1, passed=0, failed=0, xfailed=0)
     result.stdout.fnmatch_lines(
-        "!!!!!! _pytest.outcomes.Exit: Exiting pytest due to: <class 'pytest_splunk_addon.event_ingestors.hec_event_ingestor.HECEventIngestorException'> !!!!!!!"
+        "! _pytest.outcomes.Exit: Exiting pytest due to: <class 'pytest_splunk_addon.event_ingestors.hec_event_ingestor.HECIngestorException'> !"
     )
 
     assert result.ret != 0


### PR DESCRIPTION
This PR introduces specific HECEventIngestorException to be thrown when provided HEC token is not proper (change necessary due to https://splunk.atlassian.net/browse/ADDON-72764. 
It also implements throwing exception on other pytest workers (in case it was thrown on the main worker). 