### PR TITLE
fix: add hec token validation2

### DIFF
--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -639,6 +639,7 @@ def splunk_external(request):
             "Could not connect to Splunk HEC"
             "Please check the log file for possible errors."
         )
+    is_valid_hec(request, splunk_info)
     return splunk_info
 
 
@@ -1014,6 +1015,36 @@ def is_responsive(url):
             str(e),
         )
         return False
+
+
+def is_valid_hec(request, splunk):
+    """
+    Verify if provided hec token is valid by sending simple post request.
+
+    Args:
+        splunk (dict): details of the Splunk instance
+
+    Returns:
+        None
+    """
+
+    LOGGER.info(
+        "Validating HEC token...  splunk=%s",
+        json.dumps(splunk),
+    )
+    response = requests.post(
+        url=f'{request.config.getoption("splunk_hec_scheme")}://{splunk["forwarder_host"]}:{splunk["port_hec"]}/services/collector/raw',
+        headers={
+            "Authorization": f'Splunk {request.config.getoption("splunk_hec_token")}'
+        },
+        data={"event": "test_hec", "sourcetype": "hec_token_test"},
+        verify=False,
+    )
+    LOGGER.debug("Status code: {}".format(response.status_code))
+    if response.status_code == 200:
+        LOGGER.info("Splunk HEC is valid.")
+    else:
+        pytest.exit("Exiting pytest due to invalid HEC token value.")
 
 
 def pytest_unconfigure(config):


### PR DESCRIPTION
This PR adds validation of HEC token. It just checks if an event can be send via given HEC token to external Splunk.
Fix was tested locally. The result for 3 workers are presented in the attached screenshot (with pytest-splunk-addon code from develop branch it breaks main worker , restarts it and wait indefinitely).
Although splunk_external fixture is defined in the session scope it runs on each worker separately.
The following question arises: is it expected behaviour, or it's something we'd like to change (for the fixture logic to be executed before pytest splits for several processes). I do not believe that we have to check if Splunk is responsive from each worker separately. That would need to be explored (such solution might not be compatible with pytest):
![image](https://github.com/user-attachments/assets/95bd1c7c-d6ed-43d7-8249-7475e4760808)
