### PR TITLE
ci: fix ubuntu version to 22.04

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: apache/skywalking-eyes@v0.6.0
   
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -132,7 +132,7 @@ jobs:
       - fossa-scan
       - compliance-copyrights
       - test-splunk-unit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -166,7 +166,7 @@ jobs:
     needs:
       - test-splunk-external
       - test-splunk-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -53,12 +53,12 @@ jobs:
       - uses: apache/skywalking-eyes@v0.6.0
   
   pre-commit:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.7"
+          python-version: "3.12"
       - uses: pre-commit/action@v3.0.1
 
   semgrep:


### PR DESCRIPTION
This PR sets ubuntu version to 22.04 for scripts run with python 3.7.
Reference: [ADDON-75861](https://splunk.atlassian.net/browse/ADDON-75861)