### PR TITLE
chore: downgrade ubuntu version

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   meta:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       matrix_supportedSplunk: ${{ steps.matrix.outputs.supportedSplunk }}
     steps:
@@ -25,7 +25,7 @@ jobs:
 
   fossa-scan:
     continue-on-error: true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: run fossa anlyze and create report
@@ -47,13 +47,13 @@ jobs:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
   
   compliance-copyrights:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: apache/skywalking-eyes@v0.6.0
   
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -62,7 +62,7 @@ jobs:
       - uses: pre-commit/action@v3.0.1
 
   semgrep:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: security-sast-semgrep
     steps:
       - uses: actions/checkout@v4
@@ -72,7 +72,7 @@ jobs:
           publishToken: ${{ secrets.SEMGREP_PUBLISH_TOKEN }}
 
   test-splunk-unit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -85,7 +85,7 @@ jobs:
 
 
   test-splunk-external:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - meta
       - pre-commit
@@ -137,7 +137,7 @@ jobs:
       - fossa-scan
       - compliance-copyrights
       - test-splunk-unit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -171,7 +171,7 @@ jobs:
     needs:
       - test-splunk-external
       - test-splunk-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Downgrading Ubuntu version as python 3.7 is no longer supported on latest