### PR TITLE
fix: terminate tests for improper props conf

### DIFF
--- a/pytest_splunk_addon/addon_parser/transforms_parser.py
+++ b/pytest_splunk_addon/addon_parser/transforms_parser.py
@@ -23,6 +23,7 @@ import logging
 import re
 import os
 import csv
+import sys
 
 import addonfactory_splunk_conf_parser_lib as conf_parser
 
@@ -114,6 +115,7 @@ class TransformsParser(object):
             LOGGER.error(
                 f"The stanza {transforms_stanza} does not exists in transforms.conf."
             )
+            sys.exit(1)
 
     def get_lookup_csv_fields(self, lookup_stanza: str) -> Optional[Generator]:
         """

--- a/pytest_splunk_addon/addon_parser/transforms_parser.py
+++ b/pytest_splunk_addon/addon_parser/transforms_parser.py
@@ -23,7 +23,7 @@ import logging
 import re
 import os
 import csv
-import pytest
+import sys
 
 import addonfactory_splunk_conf_parser_lib as conf_parser
 
@@ -115,7 +115,7 @@ class TransformsParser(object):
             LOGGER.error(
                 f"The stanza {transforms_stanza} does not exists in transforms.conf."
             )
-            pytest.exit(
+            sys.exit(
                 f"The stanza {transforms_stanza} does not exists in transforms.conf."
             )
 

--- a/pytest_splunk_addon/addon_parser/transforms_parser.py
+++ b/pytest_splunk_addon/addon_parser/transforms_parser.py
@@ -23,7 +23,7 @@ import logging
 import re
 import os
 import csv
-import sys
+import pytest
 
 import addonfactory_splunk_conf_parser_lib as conf_parser
 
@@ -115,7 +115,9 @@ class TransformsParser(object):
             LOGGER.error(
                 f"The stanza {transforms_stanza} does not exists in transforms.conf."
             )
-            sys.exit(1)
+            pytest.exit(
+                f"The stanza {transforms_stanza} does not exists in transforms.conf."
+            )
 
     def get_lookup_csv_fields(self, lookup_stanza: str) -> Optional[Generator]:
         """

--- a/tests/e2e/addons/TA_broken/default/props.conf
+++ b/tests/e2e/addons/TA_broken/default/props.conf
@@ -58,7 +58,6 @@ LOOKUP-PASS_test_lookup_not_found = broken-NaN_lookup FAIL_component FAIL_broken
 REPORT-broken-FAIL_tsc-delim-fields = broken-tsc-delim-fields
 REPORT-broken-PASS_tsc-sk-regex-format = broken-tsc-sk-regex-format
 REPORT-broken-FAIL_tsc-sk-delim-format = broken-contact_mode_extract
-# If a non_existing stanza is present then no testcases are generated for it.
 REPORT-broken-FAIL_tsc-regex-format = broken-tsc-regex-format
 
 # Component tested: FIELDALIAS

--- a/tests/e2e/addons/TA_broken/default/props.conf
+++ b/tests/e2e/addons/TA_broken/default/props.conf
@@ -59,7 +59,7 @@ REPORT-broken-FAIL_tsc-delim-fields = broken-tsc-delim-fields
 REPORT-broken-PASS_tsc-sk-regex-format = broken-tsc-sk-regex-format
 REPORT-broken-FAIL_tsc-sk-delim-format = broken-contact_mode_extract
 # If a non_existing stanza is present then no testcases are generated for it.
-REPORT-broken-FAIL_tsc-regex-format = broken-tsc-regex-format, broken-non_existing_transforms_stanza
+REPORT-broken-FAIL_tsc-regex-format = broken-tsc-regex-format
 
 # Component tested: FIELDALIAS
 # Scenario: Plugin searches for the original field and one or more alias field names.

--- a/tests/unit/tests_standard_lib/test_addon_parser/test_transforms_parser.py
+++ b/tests/unit/tests_standard_lib/test_addon_parser/test_transforms_parser.py
@@ -61,13 +61,14 @@ def test_no_transforms_config_file():
     assert transforms_parser.transforms is None
 
 
-def test_stanza_does_not_exist_in_transforms(caplog):
+def test_stanza_does_not_exist_in_transforms():
     transforms_conf_path = os.path.join(os.path.dirname(__file__), "testdata")
     transforms_parser = TransformsParser(transforms_conf_path)
-    for result in transforms_parser.get_transform_fields("dummy_stanza"):
-        assert result is None
-    assert (
-        "The stanza dummy_stanza does not exists in transforms.conf." in caplog.messages
+    with pytest.raises(SystemExit) as excinfo:
+        for result in transforms_parser.get_transform_fields("dummy_stanza"):
+            assert result is None
+    assert "The stanza dummy_stanza does not exists in transforms.conf." == str(
+        excinfo.value
     )
 
 


### PR DESCRIPTION
props.conf had invalid syntax using line breakers (issue reported here: https://splunk.atlassian.net/browse/ADDON-72549 
). The incorrect format is causing warnings in the splunkd log, which could be easily prevented by correcting the props conf file like in this [example](https://github.com/splunk/splunk-add-on-for-microsoft-cloud-services/pull/1196/files).

Related Jira:
https://splunk.atlassian.net/browse/ADDON-77954

Example local run: 
<img width="1707" alt="image" src="https://github.com/user-attachments/assets/33e5247b-0f93-494c-9685-a48ddfb43a67" />
