### PR TITLE
Revert "fix: terminate tests for improper props conf"

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -97,8 +97,6 @@ jobs:
           submodules: true
       - name: Setup for testing
         run: |
-          pip install --upgrade pip
-          pip install git+https://github.com/pixelb/crudini
           mkdir test-results-${{ matrix.splunk.version }}
       - name: Test
         run: |

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -97,6 +97,7 @@ jobs:
           submodules: true
       - name: Setup for testing
         run: |
+          pip install --upgrade pip
           pip install git+https://github.com/pixelb/crudini
           mkdir test-results-${{ matrix.splunk.version }}
       - name: Test

--- a/pytest_splunk_addon/addon_parser/transforms_parser.py
+++ b/pytest_splunk_addon/addon_parser/transforms_parser.py
@@ -23,7 +23,6 @@ import logging
 import re
 import os
 import csv
-import sys
 
 import addonfactory_splunk_conf_parser_lib as conf_parser
 
@@ -113,9 +112,6 @@ class TransformsParser(object):
                         yield each_field.strip()
         except KeyError:
             LOGGER.error(
-                f"The stanza {transforms_stanza} does not exists in transforms.conf."
-            )
-            sys.exit(
                 f"The stanza {transforms_stanza} does not exists in transforms.conf."
             )
 

--- a/tests/e2e/addons/TA_broken/default/props.conf
+++ b/tests/e2e/addons/TA_broken/default/props.conf
@@ -58,7 +58,8 @@ LOOKUP-PASS_test_lookup_not_found = broken-NaN_lookup FAIL_component FAIL_broken
 REPORT-broken-FAIL_tsc-delim-fields = broken-tsc-delim-fields
 REPORT-broken-PASS_tsc-sk-regex-format = broken-tsc-sk-regex-format
 REPORT-broken-FAIL_tsc-sk-delim-format = broken-contact_mode_extract
-REPORT-broken-FAIL_tsc-regex-format = broken-tsc-regex-format
+# If a non_existing stanza is present then no testcases are generated for it.
+REPORT-broken-FAIL_tsc-regex-format = broken-tsc-regex-format, broken-non_existing_transforms_stanza
 
 # Component tested: FIELDALIAS
 # Scenario: Plugin searches for the original field and one or more alias field names.

--- a/tests/unit/tests_standard_lib/test_addon_parser/test_transforms_parser.py
+++ b/tests/unit/tests_standard_lib/test_addon_parser/test_transforms_parser.py
@@ -61,14 +61,13 @@ def test_no_transforms_config_file():
     assert transforms_parser.transforms is None
 
 
-def test_stanza_does_not_exist_in_transforms():
+def test_stanza_does_not_exist_in_transforms(caplog):
     transforms_conf_path = os.path.join(os.path.dirname(__file__), "testdata")
     transforms_parser = TransformsParser(transforms_conf_path)
-    with pytest.raises(SystemExit) as excinfo:
-        for result in transforms_parser.get_transform_fields("dummy_stanza"):
-            assert result is None
-    assert "The stanza dummy_stanza does not exists in transforms.conf." == str(
-        excinfo.value
+    for result in transforms_parser.get_transform_fields("dummy_stanza"):
+        assert result is None
+    assert (
+        "The stanza dummy_stanza does not exists in transforms.conf." in caplog.messages
     )
 
 


### PR DESCRIPTION
Reverts splunk/pytest-splunk-addon#901
We decided to keep the check for conf files in app inspect (the check is already implemented, but requires a fix) : https://splunk.atlassian.net/browse/A3-1577

Also upgraded pip for test-splunk-external job: https://github.com/splunk/pytest-splunk-addon/actions/runs/13541590970/job/37843909257#step:3:19