### PR TITLE
fix: improve hec batch to be not a JSON array to conform specification

### DIFF
--- a/pytest_splunk_addon/event_ingestors/hec_event_ingestor.py
+++ b/pytest_splunk_addon/event_ingestors/hec_event_ingestor.py
@@ -54,7 +54,7 @@ class HECEventIngestor(EventIngestor):
         """
         Ingests event and metric data into splunk using HEC token via event endpoint.
 
-        For batch ingestion of events in a single request at event endpoint provide a list of event dict to be ingested.
+        For batch ingestion of events in a single request at event endpoint provide stacked events one after the other to be ingested.
 
         The format of dictionary for ingesting a single event::
 
@@ -65,22 +65,20 @@ class HECEventIngestor(EventIngestor):
                 "event": "event_str"
             }
 
-        The format of dictionary for ingesting a batch of events::
+        The format for ingesting a batch of events::
 
-            [
-                {
-                    "sourcetype": "sample_HEC",
-                    "source": "sample_source",
-                    "host": "sample_host",
-                    "event": "event_str1"
-                },
-                {
-                    "sourcetype": "sample_HEC",
-                    "source": "sample_source",
-                    "host": "sample_host",
-                    "event": "event_str2"
-                },
-            ]
+            {
+                "sourcetype": "sample_HEC",
+                "source": "sample_source",
+                "host": "sample_host",
+                "event": "event_str1"
+            }
+            {
+                "sourcetype": "sample_HEC",
+                "source": "sample_source",
+                "host": "sample_host",
+                "event": "event_str2"
+            }
 
         Args:
             events (list): List of events (SampleEvent) to be ingested
@@ -117,7 +115,7 @@ class HECEventIngestor(EventIngestor):
 
     def __ingest(self, data):
         try:
-            batch_data = "".join(json.dumps(obj) for obj in data)
+            batch_data = "\n".join(json.dumps(obj) for obj in data)
             LOGGER.info(
                 "Making a HEC event request with the following params:\nhec_uri:{}\nheaders:{}".format(
                     str(self.hec_uri), str(self.session_headers)

--- a/pytest_splunk_addon/event_ingestors/hec_event_ingestor.py
+++ b/pytest_splunk_addon/event_ingestors/hec_event_ingestor.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import json
+
 from .base_event_ingestor import EventIngestor
 import requests
 from time import time, mktime
@@ -115,6 +117,7 @@ class HECEventIngestor(EventIngestor):
 
     def __ingest(self, data):
         try:
+            batch_data = "".join(json.dumps(obj) for obj in data)
             LOGGER.info(
                 "Making a HEC event request with the following params:\nhec_uri:{}\nheaders:{}".format(
                     str(self.hec_uri), str(self.session_headers)
@@ -122,13 +125,13 @@ class HECEventIngestor(EventIngestor):
             )
             LOGGER.debug(
                 "Creating the following sample event to be ingested via HEC event endoipnt:{}".format(
-                    str(data)
+                    str(batch_data)
                 )
             )
             response = requests.post(  # nosemgrep: splunk.disabled-cert-validation
                 "{}/{}".format(self.hec_uri, "event"),
                 auth=None,
-                json=data,
+                data=batch_data,
                 headers=self.session_headers,
                 verify=False,
             )

--- a/tests/unit/tests_standard_lib/test_event_ingestors/conftest.py
+++ b/tests/unit/tests_standard_lib/test_event_ingestors/conftest.py
@@ -68,26 +68,26 @@ def modinput_posts_sent():
     return [
         (
             f"POST {HEC_URI}/event",
-            "[{"
+            "{"
             '"sourcetype": "test:indextime:sourcetype:modinput_host_event_time_plugin", '
             '"source": "pytest-splunk-addon:modinput", '
             '"event": "test_modinput_1 host=modinput_host_event_time_plugin.samples_1", '
             '"index": "main", '
             '"host": "modinput_host_event_time_plugin.samples_1"'
-            "}, {"
+            "}{"
             '"sourcetype": "test:indextime:sourcetype:modinput_host_event_time_plugin", '
             '"source": "pytest-splunk-addon:modinput", '
             '"event": "test_modinput_2 host=modinput_host_event_time_plugin.samples_2", '
             '"index": "main", '
             '"host": "modinput_host_event_time_plugin.samples_2"'
-            "}, {"
+            "}{"
             '"sourcetype": "pytest_splunk_addon", '
             '"source": "pytest_splunk_addon:hec:event", '
             '"event": "fake event nothing happened", '
             '"index": "fake_index", '
             '"host": "fake host", '
             '"time": 1234.5678'
-            "}]",
+            "}",
         )
     ]
 

--- a/tests/unit/tests_standard_lib/test_event_ingestors/conftest.py
+++ b/tests/unit/tests_standard_lib/test_event_ingestors/conftest.py
@@ -74,13 +74,13 @@ def modinput_posts_sent():
             '"event": "test_modinput_1 host=modinput_host_event_time_plugin.samples_1", '
             '"index": "main", '
             '"host": "modinput_host_event_time_plugin.samples_1"'
-            "}{"
+            "}\n{"
             '"sourcetype": "test:indextime:sourcetype:modinput_host_event_time_plugin", '
             '"source": "pytest-splunk-addon:modinput", '
             '"event": "test_modinput_2 host=modinput_host_event_time_plugin.samples_2", '
             '"index": "main", '
             '"host": "modinput_host_event_time_plugin.samples_2"'
-            "}{"
+            "}\n{"
             '"sourcetype": "pytest_splunk_addon", '
             '"source": "pytest_splunk_addon:hec:event", '
             '"event": "fake event nothing happened", '


### PR DESCRIPTION
improve hec batch to be not a JSON array to conform specification: https://docs.splunk.com/Documentation/Splunk/latest/Data/FormateventsforHTTPEventCollector#Example_3:_Batched_data (ADDON-79329)