### PR TITLE
feat: add support of python3.13 with CIM v5

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -17,11 +17,11 @@ jobs:
   meta:
     runs-on: ubuntu-latest
     outputs:
-      matrix_supportedSplunk: ${{ steps.matrix.outputs.supportedSplunk }}
+      matrix_supportedSplunk: ${{ steps.matrix.outputs.latestSplunk }}
     steps:
       - uses: actions/checkout@v4
       - id: matrix
-        uses: splunk/addonfactory-test-matrix-action@v1
+        uses: splunk/addonfactory-test-matrix-action@v3
 
   fossa-scan:
     continue-on-error: true

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -15,17 +15,19 @@ concurrency:
 
 jobs:
   meta:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       matrix_supportedSplunk: ${{ steps.matrix.outputs.latestSplunk }}
     steps:
       - uses: actions/checkout@v4
       - id: matrix
         uses: splunk/addonfactory-test-matrix-action@v3
+        with:
+          features: PYTHON39
 
   fossa-scan:
     continue-on-error: true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: run fossa anlyze and create report
@@ -47,18 +49,18 @@ jobs:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
   
   compliance-copyrights:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: apache/skywalking-eyes@v0.6.0
   
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.7"
+          python-version: "3.13"
       - uses: pre-commit/action@v3.0.1
 
   semgrep:
@@ -67,11 +69,14 @@ jobs:
       SEMGREP_KEY: ${{ secrets.SEMGREP_PUBLISH_TOKEN }}
 
   test-splunk-unit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
       - name: Install dependencies
         run: |
           curl -sSL https://install.python-poetry.org | python3 - --version 1.5.1
@@ -80,7 +85,7 @@ jobs:
 
 
   test-splunk-external:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - meta
       - pre-commit
@@ -132,7 +137,7 @@ jobs:
       - fossa-scan
       - compliance-copyrights
       - test-splunk-unit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -156,7 +161,7 @@ jobs:
           submodules: true
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.13
       - run: |
           curl -sSL https://install.python-poetry.org | python3 - --version 1.5.1
           poetry install
@@ -166,7 +171,7 @@ jobs:
     needs:
       - test-splunk-external
       - test-splunk-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Dockerfile.splunk
+++ b/Dockerfile.splunk
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Dockerfile.uf
+++ b/Dockerfile.uf
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -87,6 +87,7 @@ services:
       - SPLUNK_PASSWORD=${SPLUNK_PASSWORD}
       - SPLUNK_HEC_TOKEN=${SPLUNK_HEC_TOKEN}
       - SPLUNK_START_ARGS=--accept-license
+      - SPLUNK_GENERAL_TERMS=--accept-sgt-current-at-splunk-com
       - TEST_SC4S_ACTIVATE_EXAMPLES=yes
 volumes:
   results:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,7 @@ services:
     environment:
       - SPLUNK_PASSWORD=${SPLUNK_PASSWORD}
       - SPLUNK_START_ARGS=--accept-license
+      - SPLUNK_GENERAL_TERMS=--accept-sgt-current-at-splunk-com
       - SPLUNK_HEC_TOKEN=${SPLUNK_HEC_TOKEN}
       - TEST_SC4S_ACTIVATE_EXAMPLES=yes
 
@@ -99,6 +100,7 @@ services:
     environment:
       - SPLUNK_PASSWORD=Chang3d!
       - SPLUNK_START_ARGS=--accept-license
+      - SPLUNK_GENERAL_TERMS=--accept-sgt-current-at-splunk-com
     volumes:
       - ${CURRENT_DIR}/uf_files:${CURRENT_DIR}/uf_files
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,9 @@ services:
       - "6514"
     stdin_open: true
     tty: true
-    links:
-      - splunk
+    depends_on:
+      splunk:
+        condition: service_healthy
     environment:
       - SPLUNK_HEC_URL=https://splunk:8088
       - SPLUNK_HEC_TOKEN=${SPLUNK_HEC_TOKEN}
@@ -92,8 +93,9 @@ services:
     ports:
       - "9997"
       - "8089"
-    links:
-      - splunk
+    depends_on:
+      splunk:
+        condition: service_healthy
     environment:
       - SPLUNK_PASSWORD=Chang3d!
       - SPLUNK_START_ARGS=--accept-license

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest-ci.ini
+++ b/pytest-ci.ini
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/CIM_Models/__init__.py
+++ b/pytest_splunk_addon/CIM_Models/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/CIM_Models/datamodel_definition.py
+++ b/pytest_splunk_addon/CIM_Models/datamodel_definition.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/__init__.py
+++ b/pytest_splunk_addon/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/addon_parser/__init__.py
+++ b/pytest_splunk_addon/addon_parser/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/addon_parser/eventtype_parser.py
+++ b/pytest_splunk_addon/addon_parser/eventtype_parser.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/addon_parser/fields.py
+++ b/pytest_splunk_addon/addon_parser/fields.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/addon_parser/props_parser.py
+++ b/pytest_splunk_addon/addon_parser/props_parser.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/addon_parser/props_parser.py
+++ b/pytest_splunk_addon/addon_parser/props_parser.py
@@ -203,7 +203,7 @@ class PropsParser(object):
                 yield field
 
         # If SOURCE_KEY is used in EXTRACT, generate the test for the same.
-        regex_for_source_key = r"(?:(?i)in\s+(\w+))\s*$"
+        regex_for_source_key = r"(?i)(?:in\s+(\w+))\s*$"
         extract_source_key = re.search(regex_for_source_key, value, re.MULTILINE)
         if extract_source_key:
             LOGGER.info(f"Found a source key in {name}")
@@ -260,7 +260,7 @@ class PropsParser(object):
         """
         regex = (
             r"(\"(?:\\\"|[^\"])*\"|\'(?:\\\'|[^\'])*\'|[^\s,]+)"
-            r"\s+(?i)(?:as(?:new)?)\s+"
+            r"\s+(?:as(?:new)?)\s+"
             r"(\"(?:\\\"|[^\"])*\"|\'(?:\\\'|[^\'])*\'|[^\s,]+)"
         )
         fields_tuples = re.findall(regex, value, re.IGNORECASE)

--- a/pytest_splunk_addon/addon_parser/savedsearches_parser.py
+++ b/pytest_splunk_addon/addon_parser/savedsearches_parser.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/addon_parser/tags_parser.py
+++ b/pytest_splunk_addon/addon_parser/tags_parser.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/addon_parser/transforms_parser.py
+++ b/pytest_splunk_addon/addon_parser/transforms_parser.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/app_test_generator.py
+++ b/pytest_splunk_addon/app_test_generator.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/cim_compliance/__init__.py
+++ b/pytest_splunk_addon/cim_compliance/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/cim_compliance/base_report.py
+++ b/pytest_splunk_addon/cim_compliance/base_report.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/cim_compliance/base_table.py
+++ b/pytest_splunk_addon/cim_compliance/base_table.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/cim_compliance/cim_report_generator.py
+++ b/pytest_splunk_addon/cim_compliance/cim_report_generator.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/cim_compliance/markdown_report.py
+++ b/pytest_splunk_addon/cim_compliance/markdown_report.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/cim_compliance/markdown_table.py
+++ b/pytest_splunk_addon/cim_compliance/markdown_table.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/cim_compliance/plugin.py
+++ b/pytest_splunk_addon/cim_compliance/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/cim_tests/__init__.py
+++ b/pytest_splunk_addon/cim_tests/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/cim_tests/base_schema.py
+++ b/pytest_splunk_addon/cim_tests/base_schema.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/cim_tests/data_model.py
+++ b/pytest_splunk_addon/cim_tests/data_model.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/cim_tests/data_model_handler.py
+++ b/pytest_splunk_addon/cim_tests/data_model_handler.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/cim_tests/data_set.py
+++ b/pytest_splunk_addon/cim_tests/data_set.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/cim_tests/field_test_adapter.py
+++ b/pytest_splunk_addon/cim_tests/field_test_adapter.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/cim_tests/field_test_helper.py
+++ b/pytest_splunk_addon/cim_tests/field_test_helper.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/cim_tests/json_schema.py
+++ b/pytest_splunk_addon/cim_tests/json_schema.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/cim_tests/test_generator.py
+++ b/pytest_splunk_addon/cim_tests/test_generator.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/cim_tests/test_templates.py
+++ b/pytest_splunk_addon/cim_tests/test_templates.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/docker_class.py
+++ b/pytest_splunk_addon/docker_class.py
@@ -65,7 +65,7 @@ class Services(object):
 
         :param services: the names of the services as defined in compose file
         """
-        self._docker_compose.execute("up", "--build", "-d", *services)
+        self._docker_compose.execute("up", "--build", "--wait", *services)
 
     def stop(self, *services):
         """Ensures that the given services are stopped via docker compose.

--- a/pytest_splunk_addon/event_ingestors/__init__.py
+++ b/pytest_splunk_addon/event_ingestors/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/event_ingestors/base_event_ingestor.py
+++ b/pytest_splunk_addon/event_ingestors/base_event_ingestor.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/event_ingestors/file_monitor_ingestor.py
+++ b/pytest_splunk_addon/event_ingestors/file_monitor_ingestor.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/event_ingestors/hec_event_ingestor.py
+++ b/pytest_splunk_addon/event_ingestors/hec_event_ingestor.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/event_ingestors/hec_metric_ingestor.py
+++ b/pytest_splunk_addon/event_ingestors/hec_metric_ingestor.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/event_ingestors/hec_raw_ingestor.py
+++ b/pytest_splunk_addon/event_ingestors/hec_raw_ingestor.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/event_ingestors/ingestor_helper.py
+++ b/pytest_splunk_addon/event_ingestors/ingestor_helper.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/event_ingestors/sc4s_event_ingestor.py
+++ b/pytest_splunk_addon/event_ingestors/sc4s_event_ingestor.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/fields_tests/__init__.py
+++ b/pytest_splunk_addon/fields_tests/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/fields_tests/field_bank.py
+++ b/pytest_splunk_addon/fields_tests/field_bank.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/fields_tests/requirement_test_datamodel_tag_constants.py
+++ b/pytest_splunk_addon/fields_tests/requirement_test_datamodel_tag_constants.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/fields_tests/sample_parser.py
+++ b/pytest_splunk_addon/fields_tests/sample_parser.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/fields_tests/test_generator.py
+++ b/pytest_splunk_addon/fields_tests/test_generator.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/fields_tests/test_templates.py
+++ b/pytest_splunk_addon/fields_tests/test_templates.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/index_tests/__init__.py
+++ b/pytest_splunk_addon/index_tests/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/index_tests/key_fields.py
+++ b/pytest_splunk_addon/index_tests/key_fields.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/index_tests/test_generator.py
+++ b/pytest_splunk_addon/index_tests/test_generator.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/index_tests/test_templates.py
+++ b/pytest_splunk_addon/index_tests/test_templates.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/plugin.py
+++ b/pytest_splunk_addon/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/sample_generation/__init__.py
+++ b/pytest_splunk_addon/sample_generation/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/sample_generation/pytest_splunk_addon_data_parser.py
+++ b/pytest_splunk_addon/sample_generation/pytest_splunk_addon_data_parser.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/sample_generation/rule.py
+++ b/pytest_splunk_addon/sample_generation/rule.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/sample_generation/rule.py
+++ b/pytest_splunk_addon/sample_generation/rule.py
@@ -188,7 +188,7 @@ class Rule:
                             .replace(".", "-")
                         )
                         host_split = host.split("-")
-                        if re.match("\d+", host_split[-1]):
+                        if re.match(r"\d+", host_split[-1]):
                             host = "-".join(host_split[:-1])
                         new_event.metadata["host"] = "{}-{}".format(
                             host, event_host_count
@@ -327,7 +327,7 @@ class FloatRule(Rule):
         float_match = re.match(r"[Ff]loat\[(-?[\d\.]+):(-?[\d\.]+)\]", self.replacement)
         if float_match:
             lower_limit, upper_limit = float_match.groups()
-            precision = re.search("\[-?\d+\.?(\d*):", self.replacement).group(1)
+            precision = re.search(r"\[-?\d+\.?(\d*):", self.replacement).group(1)
             if not precision:
                 precision = str(1)
             for _ in range(token_count):
@@ -681,7 +681,7 @@ class TimeRule(Rule):
             yield self.token
         for _ in range(token_count):
             random_time = datetime.fromtimestamp(
-                randint(earliest_in_epoch, latest_in_epoch)
+                randint(int(earliest_in_epoch), int(latest_in_epoch))
             )
             if timezone_time in ["local", '"local"', "'local'"]:
                 random_time = random_time.replace(tzinfo=timezone.utc).astimezone(

--- a/pytest_splunk_addon/sample_generation/sample_event.py
+++ b/pytest_splunk_addon/sample_generation/sample_event.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/sample_generation/sample_generator.py
+++ b/pytest_splunk_addon/sample_generation/sample_generator.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/sample_generation/sample_stanza.py
+++ b/pytest_splunk_addon/sample_generation/sample_stanza.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/sample_generation/sample_stanza.py
+++ b/pytest_splunk_addon/sample_generation/sample_stanza.py
@@ -25,7 +25,7 @@ from collections import namedtuple
 
 LOGGER = logging.getLogger("pytest-splunk-addon")
 
-TIMEZONE_REX = "((\+1[0-2])|(-1[0-4])|[+|-][0][0-9])([0-5][0-9])"
+TIMEZONE_REX = r"((\+1[0-2])|(-1[0-4])|[+|-][0][0-9])([0-5][0-9])"
 BULK_EVENT_COUNT = 250
 
 token_value = namedtuple("token_value", ["key", "value"])

--- a/pytest_splunk_addon/sample_generation/sample_xdist_generator.py
+++ b/pytest_splunk_addon/sample_generation/sample_xdist_generator.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/sample_generation/time_parser.py
+++ b/pytest_splunk_addon/sample_generation/time_parser.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -490,14 +490,6 @@ def uf_docker(docker_services, tmp_path_factory, worker_id, request):
     """
     Provides IP of the uf server and management port based on pytest-args(splunk_type)
     """
-    LOGGER.info("Starting docker_service=uf")
-    os.environ["CURRENT_DIR"] = os.getcwd()
-    if worker_id:
-        # get the temp directory shared by all workers
-        root_tmp_dir = tmp_path_factory.getbasetemp().parent
-        fn = root_tmp_dir / "pytest_docker"
-        with FileLock(str(fn) + ".lock"):
-            docker_services.start("uf")
     uf_info = {
         "uf_host": docker_services.docker_ip,
         "uf_port": docker_services.port_for("uf", 8089),
@@ -540,6 +532,7 @@ def splunk_docker(
     """
     # configuration of environment variables needed by docker-compose file
     os.environ["SPLUNK_APP_PACKAGE"] = request.config.getoption("splunk_app")
+    os.environ["CURRENT_DIR"] = os.getcwd()
     try:
         config = configparser.ConfigParser()
         config.read(
@@ -558,14 +551,14 @@ def splunk_docker(
     os.environ["SPLUNK_VERSION"] = request.config.getoption("splunk_version")
     os.environ["SC4S_VERSION"] = request.config.getoption("sc4s_version")
 
-    LOGGER.info("Starting docker_service=splunk")
+    LOGGER.info("Starting docker services")
     if worker_id:
         # get the temp directory shared by all workers
         root_tmp_dir = tmp_path_factory.getbasetemp().parent
         fn = root_tmp_dir / "pytest_docker"
         # if you encounter docker-compose not found modify shell path in your IDE to use /bin/bash
         with FileLock(str(fn) + ".lock"):
-            docker_services.start("splunk")
+            docker_services.start()
 
     splunk_info = {
         "host": docker_services.docker_ip,
@@ -648,13 +641,6 @@ def sc4s_docker(docker_services, tmp_path_factory, worker_id):
     """
     Provides IP of the sc4s server and related ports based on pytest-args(splunk_type)
     """
-    if worker_id:
-        # get the temp directory shared by all workers
-        root_tmp_dir = tmp_path_factory.getbasetemp().parent
-        fn = root_tmp_dir / "pytest_docker"
-        with FileLock(str(fn) + ".lock"):
-            docker_services.start("sc4s")
-
     ports = {514: docker_services.port_for("sc4s", 514)}
     for x in range(5000, 5007):
         ports.update({x: docker_services.port_for("sc4s", x)})

--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -856,7 +856,7 @@ def docker_ip():
     if not docker_host:
         return "127.0.0.1"
 
-    match = re.match("^tcp://(.+?):\d+$", docker_host)
+    match = re.match(r"^tcp://(.+?):\d+$", docker_host)
     if not match:
         raise ValueError('Invalid value for DOCKER_HOST: "%s".' % (docker_host,))
     return match.group(1)

--- a/pytest_splunk_addon/standard_lib/addon_basic.py
+++ b/pytest_splunk_addon/standard_lib/addon_basic.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/tools/cim_field_report.py
+++ b/pytest_splunk_addon/tools/cim_field_report.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/utilities/__init__.py
+++ b/pytest_splunk_addon/utilities/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/utilities/junit_parser.py
+++ b/pytest_splunk_addon/utilities/junit_parser.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/utilities/log_helper.py
+++ b/pytest_splunk_addon/utilities/log_helper.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/utilities/sample_splitter.py
+++ b/pytest_splunk_addon/utilities/sample_splitter.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/utilities/xml_event_parser.py
+++ b/pytest_splunk_addon/utilities/xml_event_parser.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest_splunk_addon/utils.py
+++ b/pytest_splunk_addon/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Splunk Inc.
+# Copyright 2025 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/tests_standard_lib/test_event_ingestors/test_ingestor_helper.py
+++ b/tests/unit/tests_standard_lib/test_event_ingestors/test_ingestor_helper.py
@@ -103,7 +103,7 @@ def test_ingestor_can_be_obtained(
         ingestor_helper.get_event_ingestor(ingest_method, "ingest_meta_data")
         == expected_output
     )
-    assert ingestors_mocks[expected_output].has_calls("ingest_meta_data")
+    ingestors_mocks[expected_output].assert_called_with("ingest_meta_data")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Added compatibility with python3.13 for PSA with CIM v5.

Ref: https://splunk.atlassian.net/browse/ADDON-82835