### PR TITLE
ci: fix docker env creation for e2e tests (#909)

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -17,11 +17,11 @@ jobs:
   meta:
     runs-on: ubuntu-22.04
     outputs:
-      matrix_supportedSplunk: ${{ steps.matrix.outputs.supportedSplunk }}
+      matrix_supportedSplunk: ${{ steps.matrix.outputs.latestSplunk }}
     steps:
       - uses: actions/checkout@v4
       - id: matrix
-        uses: splunk/addonfactory-test-matrix-action@v1
+        uses: splunk/addonfactory-test-matrix-action@v3
 
   fossa-scan:
     continue-on-error: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,9 @@ services:
       - "6514"
     stdin_open: true
     tty: true
-    links:
-      - splunk
+    depends_on:
+      splunk:
+        condition: service_healthy
     environment:
       - SPLUNK_HEC_URL=https://splunk:8088
       - SPLUNK_HEC_TOKEN=${SPLUNK_HEC_TOKEN}
@@ -92,8 +93,9 @@ services:
     ports:
       - "9997"
       - "8089"
-    links:
-      - splunk
+    depends_on:
+      splunk:
+        condition: service_healthy
     environment:
       - SPLUNK_PASSWORD=Chang3d!
       - SPLUNK_START_ARGS=--accept-license

--- a/pytest_splunk_addon/docker_class.py
+++ b/pytest_splunk_addon/docker_class.py
@@ -65,7 +65,7 @@ class Services(object):
 
         :param services: the names of the services as defined in compose file
         """
-        self._docker_compose.execute("up", "--build", "-d", *services)
+        self._docker_compose.execute("up", "--build", "--wait", *services)
 
     def stop(self, *services):
         """Ensures that the given services are stopped via docker compose.

--- a/pytest_splunk_addon/splunk.py
+++ b/pytest_splunk_addon/splunk.py
@@ -490,14 +490,6 @@ def uf_docker(docker_services, tmp_path_factory, worker_id, request):
     """
     Provides IP of the uf server and management port based on pytest-args(splunk_type)
     """
-    LOGGER.info("Starting docker_service=uf")
-    os.environ["CURRENT_DIR"] = os.getcwd()
-    if worker_id:
-        # get the temp directory shared by all workers
-        root_tmp_dir = tmp_path_factory.getbasetemp().parent
-        fn = root_tmp_dir / "pytest_docker"
-        with FileLock(str(fn) + ".lock"):
-            docker_services.start("uf")
     uf_info = {
         "uf_host": docker_services.docker_ip,
         "uf_port": docker_services.port_for("uf", 8089),
@@ -540,6 +532,7 @@ def splunk_docker(
     """
     # configuration of environment variables needed by docker-compose file
     os.environ["SPLUNK_APP_PACKAGE"] = request.config.getoption("splunk_app")
+    os.environ["CURRENT_DIR"] = os.getcwd()
     try:
         config = configparser.ConfigParser()
         config.read(
@@ -558,14 +551,14 @@ def splunk_docker(
     os.environ["SPLUNK_VERSION"] = request.config.getoption("splunk_version")
     os.environ["SC4S_VERSION"] = request.config.getoption("sc4s_version")
 
-    LOGGER.info("Starting docker_service=splunk")
+    LOGGER.info("Starting docker services")
     if worker_id:
         # get the temp directory shared by all workers
         root_tmp_dir = tmp_path_factory.getbasetemp().parent
         fn = root_tmp_dir / "pytest_docker"
         # if you encounter docker-compose not found modify shell path in your IDE to use /bin/bash
         with FileLock(str(fn) + ".lock"):
-            docker_services.start("splunk")
+            docker_services.start()
 
     splunk_info = {
         "host": docker_services.docker_ip,
@@ -648,13 +641,6 @@ def sc4s_docker(docker_services, tmp_path_factory, worker_id):
     """
     Provides IP of the sc4s server and related ports based on pytest-args(splunk_type)
     """
-    if worker_id:
-        # get the temp directory shared by all workers
-        root_tmp_dir = tmp_path_factory.getbasetemp().parent
-        fn = root_tmp_dir / "pytest_docker"
-        with FileLock(str(fn) + ".lock"):
-            docker_services.start("sc4s")
-
     ports = {514: docker_services.port_for("sc4s", 514)}
     for x in range(5000, 5007):
         ports.update({x: docker_services.port_for("sc4s", x)})


### PR DESCRIPTION
- Update the matrix version to get the latest splunk version to be used in e2e tests
- Fixes the issue with the e2e tests execution where the tests were failing due to issues in the docker services being created.