### PR TITLE
fix: field validation condition

### DIFF
--- a/pytest_splunk_addon/data_models/Endpoint.json
+++ b/pytest_splunk_addon/data_models/Endpoint.json
@@ -88,7 +88,7 @@
         {
           "name": "transport_dest_port",
           "type": "required",
-          "validity": "if(match(transport_dest_port, \"(?:tcp|udp|dccp|sctp)\\/(?:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})$)\"), transport_dest_port, null()",
+          "validity": "if(match(transport_dest_port, \"(?:tcp|udp|dccp|sctp)\\/(?:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})$)\"), transport_dest_port, null())",
           "comment": "Calculated as transport/dest_port, such as tcp/53."
         },
         {

--- a/pytest_splunk_addon/data_models/Endpoint.json
+++ b/pytest_splunk_addon/data_models/Endpoint.json
@@ -88,7 +88,7 @@
         {
           "name": "transport_dest_port",
           "type": "required",
-          "validity": "(?:tcp|udp|dccp|sctp)\\/(?:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})$)",
+          "validity": "if(match(transport_dest_port, \"(?:tcp|udp|dccp|sctp)\\/(?:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})$)\"), transport_dest_port, null()",
           "comment": "Calculated as transport/dest_port, such as tcp/53."
         },
         {


### PR DESCRIPTION
Fixes the issue with validation condition being used while executing SPL query to search events for particular testcase.

Reference issue: https://github.com/splunk/splunk-add-on-for-unix-and-linux/runs/49911799683

Test run: https://github.com/splunk/splunk-add-on-for-unix-and-linux/actions/runs/17581963680