### PR TITLE
chore: update psa-cim-models branch refs to cim-5/cim-6 (ADDON-86874)

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -223,9 +223,9 @@ jobs:
       matrix:
         splunk: ${{ fromJson(needs.meta.outputs.matrix_supportedSplunk) }}
         cim-models:
-          - ref: "cim-5.3.3"
+          - ref: "cim-5"
             label: "5.x"
-          - ref: "cim-6.4"
+          - ref: "cim-6"
             label: "6.x"
           # Add future releases here, e.g.:
           # - ref: "cim-7.x"


### PR DESCRIPTION
## Summary

- Updates `.github/workflows/build-test-release.yml` to reference `cim-5` and `cim-6` instead of `cim-5.3.3` and `cim-6.4` in the CIM models test matrix.

## Why

Follow-up to #955: the `psa-cim-models` repo is adopting canonical major-version branch names (`cim-5`, `cim-6`) per ADDON-86874. The versioned branches (`cim-5.3.3`, `cim-6.4`) pointed to the same commits and are being retired in favour of the shorter names.

## Test plan

- [ ] `CIM models 5.x` CI job passes using `cim-5` branch ref
- [ ] `CIM models 6.x` CI job passes using `cim-6` branch ref