### PR TITLE
chore: use cim-6 psa-cim-models branch (ADDON-86874)

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -277,7 +277,7 @@ jobs:
           # runtime error rather than a wrong-field assertion.
           #
           # splunk_cim_model (real Change/Network_Traffic models) is left to
-          # test-splunk-matrix, which always uses the default cim-6.4 dev
+          # test-splunk-matrix, which always uses the default cim-6 dev
           # dependency and asserts version-specific field outcomes.
           poetry run pytest -v \
             --splunk-version=${{ matrix.splunk.version }} \

--- a/docs/cim_tests.md
+++ b/docs/cim_tests.md
@@ -23,7 +23,7 @@ pip install splunk-cim-models
 Or, during development, install the latest from the repository:
 
 ```console
-pip install git+https://github.com/splunk/psa-cim-models.git@cim-6.4
+pip install git+https://github.com/splunk/psa-cim-models.git@cim-6
 ```
 
 The package exposes:
@@ -109,11 +109,11 @@ To generate test cases only for CIM compatibility, append the following marker t
 
  **Workflow:**
 
- - Plugin collects the list of not_allowed_in_search fields from mapped datasets and [CommonFields.json](https://github.com/splunk/psa-cim-models/blob/cim-6.4/splunk_cim_models/CommonFields.json).
+ - Plugin collects the list of not_allowed_in_search fields from mapped datasets and [CommonFields.json](https://github.com/splunk/psa-cim-models/blob/cim-6/splunk_cim_models/CommonFields.json).
  - Using search query the test case verifies if not_allowed_in_search fields are populated in search or not.
 
 > **_NOTE:_** 
- [CommonFields.json](https://github.com/splunk/psa-cim-models/blob/cim-6.4/splunk_cim_models/CommonFields.json) contains fields which are automatically provided by asset and identity correlation features of applications like Splunk Enterprise Security.
+ [CommonFields.json](https://github.com/splunk/psa-cim-models/blob/cim-6/splunk_cim_models/CommonFields.json) contains fields which are automatically provided by asset and identity correlation features of applications like Splunk Enterprise Security.
 
 
 **4. Testcase for all not_allowed_in_props fields**

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -18,7 +18,7 @@ To install currently checked out version of pytest-splunk-addon use:
 $ poetry install
 ```
 
-This installs `splunk-cim-models` automatically as a dev dependency (from the `cim-6.4` branch of
+This installs `splunk-cim-models` automatically as a dev dependency (from the `cim-6` branch of
 [psa-cim-models](https://github.com/splunk/psa-cim-models)). In CI or when installing from
 PyPI, install `splunk-cim-models` separately before running CIM tests:
 

--- a/docs/how_to_use.md
+++ b/docs/how_to_use.md
@@ -460,9 +460,9 @@ def splunk_setup(splunk):
 
  How can this be achieved :
 
-  - Make json representation of the data models, which satisfies the [DatamodelSchema](https://github.com/splunk/psa-cim-models/blob/cim-6.4/splunk_cim_models/DatamodelSchema.json) provided by the `splunk-cim-models` package.
+  - Make json representation of the data models, which satisfies the [DatamodelSchema](https://github.com/splunk/psa-cim-models/blob/cim-6/splunk_cim_models/DatamodelSchema.json) provided by the `splunk-cim-models` package.
   - Provide the path to the directory having all the data models by adding `--splunk_dm_path path_to_dir` to the pytest command.
-  - The test cases will now be generated for the data models provided to the plugin and not for the [default data models](https://github.com/splunk/psa-cim-models/tree/cim-6.4/splunk_cim_models/data_models) bundled in `splunk-cim-models`.
+  - The test cases will now be generated for the data models provided to the plugin and not for the [default data models](https://github.com/splunk/psa-cim-models/tree/cim-6/splunk_cim_models/data_models) bundled in `splunk-cim-models`.
 
 > **_NOTE:_** CIM data model definitions are provided by the [`splunk-cim-models`](https://github.com/splunk/psa-cim-models) package. Install it separately before running CIM tests:
 >

--- a/poetry.lock
+++ b/poetry.lock
@@ -770,8 +770,8 @@ develop = false
 [package.source]
 type = "git"
 url = "https://github.com/splunk/psa-cim-models.git"
-reference = "cim-6.4"
-resolved_reference = "f547c30bcd0f04690d8a4e3e963c41e76a8d23d0"
+reference = "cim-6"
+resolved_reference = "9b5c704f4cb7c7da059711d6bb84aa8768b13bc9"
 
 [[package]]
 name = "splunk-sdk"
@@ -898,4 +898,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.7"
-content-hash = "8562907cb839c6d62c0d6fb7283de5682b658cf47f82e1b1dfa81c8888d725ba"
+content-hash = "263dbb8509dcbf025d2714a2c9ab79020918b476a6775aa4967dc118ebaac2d1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ pytest-cov = "^4"
 requests-mock = "^1.8.0"
 freezegun = "^1.5.1"
 pytz = "^2024.1"
-splunk-cim-models = {git = "https://github.com/splunk/psa-cim-models.git", branch = "cim-6.4"}
+splunk-cim-models = {git = "https://github.com/splunk/psa-cim-models.git", branch = "cim-6"}
 
 [tool.poetry.plugins]
 pytest11 = { plugin = "pytest_splunk_addon.plugin", "splunk" = "pytest_splunk_addon.splunk" }


### PR DESCRIPTION
Updates pytest-splunk-addon's splunk-cim-models dev dependency and docs from the retired cim-6.4 branch to the canonical cim-6 branch for ADDON-86874. Regenerated poetry.lock with Poetry 2.1.4. Validation: poetry check --lock; git diff --check; old cim-6.4/v1/v2 reference scan.