### PR TITLE
[codex] Validate PSA against CIM 6.4 docs branch

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -277,7 +277,7 @@ jobs:
           # runtime error rather than a wrong-field assertion.
           #
           # splunk_cim_model (real Change/Network_Traffic models) is left to
-          # test-splunk-matrix, which always uses the default cim-6.4 dev
+          # test-splunk-matrix, which always uses the default cim-6 dev
           # dependency and asserts version-specific field outcomes.
           poetry run pytest -v \
             --splunk-version=${{ matrix.splunk.version }} \

--- a/docs/cim_tests.md
+++ b/docs/cim_tests.md
@@ -23,7 +23,7 @@ pip install splunk-cim-models
 Or, during development, install the latest from the repository:
 
 ```console
-pip install git+https://github.com/splunk/psa-cim-models.git@cim-6.4
+pip install git+https://github.com/splunk/psa-cim-models.git@cim-6
 ```
 
 The package exposes:
@@ -109,11 +109,11 @@ To generate test cases only for CIM compatibility, append the following marker t
 
  **Workflow:**
 
- - Plugin collects the list of not_allowed_in_search fields from mapped datasets and [CommonFields.json](https://github.com/splunk/psa-cim-models/blob/cim-6.4/splunk_cim_models/CommonFields.json).
+ - Plugin collects the list of not_allowed_in_search fields from mapped datasets and [CommonFields.json](https://github.com/splunk/psa-cim-models/blob/cim-6/splunk_cim_models/CommonFields.json).
  - Using search query the test case verifies if not_allowed_in_search fields are populated in search or not.
 
 > **_NOTE:_** 
- [CommonFields.json](https://github.com/splunk/psa-cim-models/blob/cim-6.4/splunk_cim_models/CommonFields.json) contains fields which are automatically provided by asset and identity correlation features of applications like Splunk Enterprise Security.
+ [CommonFields.json](https://github.com/splunk/psa-cim-models/blob/cim-6/splunk_cim_models/CommonFields.json) contains fields which are automatically provided by asset and identity correlation features of applications like Splunk Enterprise Security.
 
 
 **4. Testcase for all not_allowed_in_props fields**

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -18,7 +18,7 @@ To install currently checked out version of pytest-splunk-addon use:
 $ poetry install
 ```
 
-This installs `splunk-cim-models` automatically as a dev dependency (from the `cim-6.4` branch of
+This installs `splunk-cim-models` automatically as a dev dependency (from the `cim-6` branch of
 [psa-cim-models](https://github.com/splunk/psa-cim-models)). In CI or when installing from
 PyPI, install `splunk-cim-models` separately before running CIM tests:
 

--- a/docs/how_to_use.md
+++ b/docs/how_to_use.md
@@ -460,9 +460,9 @@ def splunk_setup(splunk):
 
  How can this be achieved :
 
-  - Make json representation of the data models, which satisfies the [DatamodelSchema](https://github.com/splunk/psa-cim-models/blob/cim-6.4/splunk_cim_models/DatamodelSchema.json) provided by the `splunk-cim-models` package.
+  - Make json representation of the data models, which satisfies the [DatamodelSchema](https://github.com/splunk/psa-cim-models/blob/cim-6/splunk_cim_models/DatamodelSchema.json) provided by the `splunk-cim-models` package.
   - Provide the path to the directory having all the data models by adding `--splunk_dm_path path_to_dir` to the pytest command.
-  - The test cases will now be generated for the data models provided to the plugin and not for the [default data models](https://github.com/splunk/psa-cim-models/tree/cim-6.4/splunk_cim_models/data_models) bundled in `splunk-cim-models`.
+  - The test cases will now be generated for the data models provided to the plugin and not for the [default data models](https://github.com/splunk/psa-cim-models/tree/cim-6/splunk_cim_models/data_models) bundled in `splunk-cim-models`.
 
 > **_NOTE:_** CIM data model definitions are provided by the [`splunk-cim-models`](https://github.com/splunk/psa-cim-models) package. Install it separately before running CIM tests:
 >

--- a/poetry.lock
+++ b/poetry.lock
@@ -770,8 +770,8 @@ develop = false
 [package.source]
 type = "git"
 url = "https://github.com/splunk/psa-cim-models.git"
-reference = "cim-6.4"
-resolved_reference = "f547c30bcd0f04690d8a4e3e963c41e76a8d23d0"
+reference = "cim-6"
+resolved_reference = "9b5c704f4cb7c7da059711d6bb84aa8768b13bc9"
 
 [[package]]
 name = "splunk-sdk"
@@ -898,4 +898,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.7"
-content-hash = "8562907cb839c6d62c0d6fb7283de5682b658cf47f82e1b1dfa81c8888d725ba"
+content-hash = "263dbb8509dcbf025d2714a2c9ab79020918b476a6775aa4967dc118ebaac2d1"

--- a/poetry.lock
+++ b/poetry.lock
@@ -770,8 +770,8 @@ develop = false
 [package.source]
 type = "git"
 url = "https://github.com/splunk/psa-cim-models.git"
-reference = "cim-6"
-resolved_reference = "9b5c704f4cb7c7da059711d6bb84aa8768b13bc9"
+reference = "align-cim6-4-docs"
+resolved_reference = "51ab83e81e06248fc726af213b1932c5cebebcf4"
 
 [[package]]
 name = "splunk-sdk"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ pytest-cov = "^4"
 requests-mock = "^1.8.0"
 freezegun = "^1.5.1"
 pytz = "^2024.1"
-splunk-cim-models = {git = "https://github.com/splunk/psa-cim-models.git", branch = "cim-6.4"}
+splunk-cim-models = {git = "https://github.com/splunk/psa-cim-models.git", branch = "cim-6"}
 
 [tool.poetry.plugins]
 pytest11 = { plugin = "pytest_splunk_addon.plugin", "splunk" = "pytest_splunk_addon.splunk" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ pytest-cov = "^4"
 requests-mock = "^1.8.0"
 freezegun = "^1.5.1"
 pytz = "^2024.1"
-splunk-cim-models = {git = "https://github.com/splunk/psa-cim-models.git", branch = "cim-6"}
+splunk-cim-models = {git = "https://github.com/splunk/psa-cim-models.git", branch = "align-cim6-4-docs"}
 
 [tool.poetry.plugins]
 pytest11 = { plugin = "pytest_splunk_addon.plugin", "splunk" = "pytest_splunk_addon.splunk" }


### PR DESCRIPTION
## What changed

This PR wires the `splunk-cim-models` dev dependency to the `align-cim6-4-docs` branch from `splunk/psa-cim-models` so CI can validate pytest-splunk-addon against the CIM 6.4 documentation alignment changes.

## Why

The corresponding `psa-cim-models` PR updates CIM model content for CIM 6.4 documentation alignment. Pointing PSA at that branch lets the pytest-splunk-addon CI matrix exercise the dependency before the CIM branch is merged back into `cim-6`.

## Impact

Only the development/test dependency reference changes. Runtime package code is unchanged.

## Validation

Local checks run before pushing:

- `uv pip install --no-config --python .venv/bin/python --default-index https://pypi.org/simple . pytest-cov requests-mock freezegun pytz "git+https://github.com/splunk/psa-cim-models.git@align-cim6-4-docs"`
- Verified installed metadata: `requested_revision=align-cim6-4-docs`, commit `51ab83e81e06248fc726af213b1932c5cebebcf4`
- `.venv/bin/python -m pytest -v tests/unit` -> `525 passed`
- `.venv/bin/python -m pytest -v tests/unit/tests_standard_lib/test_cim_tests/test_splunk_cim_models_contract.py` -> `25 passed`

Docker/Splunk e2e was not run locally because Docker is not installed on this machine (`docker: command not found`).