### PR TITLE
feat: add Python 3.13 compatibility CI

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -72,6 +72,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
       - name: Generate GitHub App Token
         id: app-token
         uses: actions/create-github-app-token@v3
@@ -80,6 +83,32 @@ jobs:
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Install dependencies
+        run: |
+          git config --global --add url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com".insteadOf https://github.com
+          git config --global --add url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com".insteadOf ssh://git@github.com
+          curl -sSL https://install.python-poetry.org | python3 - --version 1.5.1
+          poetry install
+          poetry run pytest -v tests/unit
+
+  test-splunk-unit-python-313:
+    # Keep this advisory while Python 3.13 compatibility is being established.
+    continue-on-error: true
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: Install dependencies and run unit tests
         run: |
           git config --global --add url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com".insteadOf https://github.com
           git config --global --add url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com".insteadOf ssh://git@github.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
         "Topic :: Software Development :: Testing",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.13",
         "Operating System :: OS Independent",
         "License :: OSI Approved :: Apache Software License",
 ]


### PR DESCRIPTION
## Summary

- add an advisory Python 3.13 PSA unit-test job
- make the established Python 3.12 unit-test runtime explicit
- declare Python 3.13 in package classifiers

## Validation

- `poetry run pytest -q tests/unit --junitxml=test-results/ADDON-89515-python-3.13-unit.xml`
- 525 passed on Python 3.13.12

## Follow-up

- review the first remote Python 3.13 CI run
- make Python 3.13 blocking in the unit-test matrix after it is stable
- validate the candidate against three representative TAs